### PR TITLE
Fix(ui, desktop, mobile): UI 패키지 SCSS 번들 미포함으로 인한 앱별 스타일 미적용 오류 수정

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -15,6 +15,7 @@ if (process.env.NODE_ENV === 'development') {
 import '@template/theme';
 
 // UI 패키지 import (스타일 포함)
+import '@template/ui/style.css';
 import '@template/ui';
 
 // 전역 스타일

--- a/apps/mobile/src/main.ts
+++ b/apps/mobile/src/main.ts
@@ -1,5 +1,6 @@
 import { useTheme } from '@template/theme';
 import { createPinia } from 'pinia';
+import '@template/ui/style.css';
 import { createApp } from 'vue';
 import App from './App.vue';
 import './style.css';

--- a/apps/moda-desktop/src/main.ts
+++ b/apps/moda-desktop/src/main.ts
@@ -15,6 +15,7 @@ if (process.env.NODE_ENV === 'development') {
 import '@template/theme';
 
 // UI 패키지 import (스타일 포함)
+import '@template/ui/style.css';
 import '@template/ui';
 
 // 전역 스타일

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,8 @@
     "./composables": {
       "types": "./dist/composables/index.d.ts",
       "import": "./dist/composables/index.js"
-    }
+    },
+    "./style.css": "./dist/style.css"
   },
   "files": [
     "dist"
@@ -44,10 +45,11 @@
     "@template/types": "workspace:*"
   },
   "devDependencies": {
-    "vite-svg-loader": "^5.1.0",
-    "tailwindcss": "^3.4.0",
     "autoprefixer": "^10.4.0",
-    "postcss": "^8.4.0"
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "vite-plugin-sass-dts": "^1.3.31",
+    "vite-svg-loader": "^5.1.0"
   },
   "peerDependencies": {
     "vue": "^3.4.0"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,5 @@
 // 스타일 import
-import './style.css';
+import './styles/index.scss';
 
 // Vue UI 컴포넌트들을 export
 export * from './components';

--- a/packages/ui/src/styles/index.scss
+++ b/packages/ui/src/styles/index.scss
@@ -1,0 +1,43 @@
+// UI 패키지 메인 스타일 파일
+// 모든 컴포넌트의 SCSS를 여기서 import하여 하나의 CSS 번들로 컴파일
+
+// BaseButton 컴포넌트 스타일
+@use '../components/BaseButton/BaseButton.scss';
+
+// BaseInput 컴포넌트 스타일
+@use '../components/BaseInput/BaseInput.scss';
+@use '../components/BaseInput/BaseInputText.scss';
+@use '../components/BaseInput/BaseInputCalendar.scss';
+@use '../components/BaseInput/BaseInputSelect.scss';
+@use '../components/BaseInput/BaseInputStepper.scss';
+
+// BaseTable 컴포넌트 스타일
+@use '../components/BaseTable/BaseTable.scss';
+@use '../components/BaseTable/BaseTableBody.scss';
+@use '../components/BaseTable/BaseTableCell.scss';
+@use '../components/BaseTable/BaseTableHead.scss';
+@use '../components/BaseTable/BaseTableRow.scss';
+@use '../components/BaseTable/TableWithPagination.scss';
+
+// BaseTabs 컴포넌트 스타일
+@use '../components/BaseTabs/BaseTabs.scss';
+
+// BasePagination 컴포넌트 스타일
+@use '../components/BasePagination/BasePaginationArrow.scss';
+@use '../components/BasePagination/BasePaginationNumber.scss';
+@use '../components/BasePagination/BasePaginationJoin.scss';
+
+// BaseProgressBar 컴포넌트 스타일
+@use '../components/BaseProgressBar/BaseProgressBar.scss';
+
+// BasePasswordStrength 컴포넌트 스타일
+@use '../components/BasePasswordStrength/BasePasswordStrength.scss';
+
+// BaseCheckbox 컴포넌트 스타일
+@use '../components/BaseCheckbox/BaseCheckbox.scss';
+
+// BaseChips 컴포넌트 스타일
+@use '../components/BaseChips/BaseChip.scss';
+
+// BaseIcon 컴포넌트 스타일
+@use '../components/BaseIcon/BaseIcon.scss'; 

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -3,6 +3,7 @@ import vue from '@vitejs/plugin-vue';
 import { resolve } from 'node:path';
 import dts from 'vite-plugin-dts';
 import svgLoader from 'vite-svg-loader';
+import path from 'node:path';
 
 export default defineConfig({
   plugins: [
@@ -38,6 +39,9 @@ export default defineConfig({
         preserveModules: true,
       },
     },
+    cssCodeSplit: false,
+    outDir: 'dist',
+    assetsDir: '.',
   },
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 8.6.14(storybook@8.6.14(prettier@3.6.2))(vue@3.5.18(typescript@5.8.3))
       '@storybook/vue3-vite':
         specifier: ^8.6.14
-        version: 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))
+        version: 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))
       '@tokens-studio/sd-transforms':
         specifier: ^2.0.1
         version: 2.0.1(style-dictionary@4.4.0)
@@ -86,7 +86,7 @@ importers:
         version: 7.18.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.8.3)
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
-        version: 6.0.1(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))
+        version: 6.0.1(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))
       '@vitest/coverage-v8':
         specifier: ^1.0.0
         version: 1.6.1(vitest@1.6.1)
@@ -170,13 +170,13 @@ importers:
         version: 8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.8.3)
       vite:
         specifier: ^5.4.19
-        version: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+        version: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@20.19.9)(rollup@4.46.2)(typescript@5.8.3)(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1))
+        version: 4.5.4(@types/node@20.19.9)(rollup@4.46.2)(typescript@5.8.3)(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
       vite-plugin-inspect:
         specifier: ^11.3.0
-        version: 11.3.2(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1))
+        version: 11.3.2(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
       vue-tsc:
         specifier: ^1.8.0
         version: 1.8.27(typescript@5.8.3)
@@ -288,7 +288,7 @@ importers:
         version: link:../utils
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@22.17.0)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+        version: 1.6.1(@types/node@22.17.0)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
 
   packages/theme:
     dependencies:
@@ -335,6 +335,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.0
         version: 3.4.17
+      vite-plugin-sass-dts:
+        specifier: ^1.3.31
+        version: 1.3.31(postcss@8.5.6)(prettier@3.6.2)(sass-embedded@1.89.2)(vite@5.4.19(@types/node@22.17.0)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
       vite-svg-loader:
         specifier: ^5.1.0
         version: 5.1.0(vue@3.5.18(typescript@5.8.3))
@@ -346,7 +349,7 @@ importers:
         version: link:../types
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@22.17.0)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+        version: 1.6.1(@types/node@22.17.0)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
       zxcvbn:
         specifier: ^4.4.2
         version: 4.4.2
@@ -872,6 +875,9 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bufbuild/protobuf@2.6.2':
+    resolution: {integrity: sha512-vLu7SRY84CV/Dd+NUdgtidn2hS5hSMUC1vDBY0VcviTdgRYkU43vIz3vIFbmx14cX1r+mM7WjzE5Fl1fGEM0RQ==}
 
   '@bundled-es-modules/deepmerge@4.3.1':
     resolution: {integrity: sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==}
@@ -2672,6 +2678,9 @@ packages:
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-builder@0.2.0:
+    resolution: {integrity: sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -5317,6 +5326,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -5326,6 +5338,107 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sass-embedded-android-arm64@1.89.2:
+    resolution: {integrity: sha512-+pq7a7AUpItNyPu61sRlP6G2A8pSPpyazASb+8AK2pVlFayCSPAEgpwpCE9A2/Xj86xJZeMizzKUHxM2CBCUxA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  sass-embedded-android-arm@1.89.2:
+    resolution: {integrity: sha512-oHAPTboBHRZlDBhyRB6dvDKh4KvFs+DZibDHXbkSI6dBZxMTT+Yb2ivocHnctVGucKTLQeT7+OM5DjWHyynL/A==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [android]
+
+  sass-embedded-android-riscv64@1.89.2:
+    resolution: {integrity: sha512-HfJJWp/S6XSYvlGAqNdakeEMPOdhBkj2s2lN6SHnON54rahKem+z9pUbCriUJfM65Z90lakdGuOfidY61R9TYg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [riscv64]
+    os: [android]
+
+  sass-embedded-android-x64@1.89.2:
+    resolution: {integrity: sha512-BGPzq53VH5z5HN8de6jfMqJjnRe1E6sfnCWFd4pK+CAiuM7iw5Fx6BQZu3ikfI1l2GY0y6pRXzsVLdp/j4EKEA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [android]
+
+  sass-embedded-darwin-arm64@1.89.2:
+    resolution: {integrity: sha512-UCm3RL/tzMpG7DsubARsvGUNXC5pgfQvP+RRFJo9XPIi6elopY5B6H4m9dRYDpHA+scjVthdiDwkPYr9+S/KGw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  sass-embedded-darwin-x64@1.89.2:
+    resolution: {integrity: sha512-D9WxtDY5VYtMApXRuhQK9VkPHB8R79NIIR6xxVlN2MIdEid/TZWi1MHNweieETXhWGrKhRKglwnHxxyKdJYMnA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  sass-embedded-linux-arm64@1.89.2:
+    resolution: {integrity: sha512-2N4WW5LLsbtrWUJ7iTpjvhajGIbmDR18ZzYRywHdMLpfdPApuHPMDF5CYzHbS+LLx2UAx7CFKBnj5LLjY6eFgQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  sass-embedded-linux-arm@1.89.2:
+    resolution: {integrity: sha512-leP0t5U4r95dc90o8TCWfxNXwMAsQhpWxTkdtySDpngoqtTy3miMd7EYNYd1znI0FN1CBaUvbdCMbnbPwygDlA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  sass-embedded-linux-musl-arm64@1.89.2:
+    resolution: {integrity: sha512-nTyuaBX6U1A/cG7WJh0pKD1gY8hbg1m2SnzsyoFG+exQ0lBX/lwTLHq3nyhF+0atv7YYhYKbmfz+sjPP8CZ9lw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  sass-embedded-linux-musl-arm@1.89.2:
+    resolution: {integrity: sha512-Z6gG2FiVEEdxYHRi2sS5VIYBmp17351bWtOCUZ/thBM66+e70yiN6Eyqjz80DjL8haRUegNQgy9ZJqsLAAmr9g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  sass-embedded-linux-musl-riscv64@1.89.2:
+    resolution: {integrity: sha512-N6oul+qALO0SwGY8JW7H/Vs0oZIMrRMBM4GqX3AjM/6y8JsJRxkAwnfd0fDyK+aICMFarDqQonQNIx99gdTZqw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  sass-embedded-linux-musl-x64@1.89.2:
+    resolution: {integrity: sha512-K+FmWcdj/uyP8GiG9foxOCPfb5OAZG0uSVq80DKgVSC0U44AdGjvAvVZkrgFEcZ6cCqlNC2JfYmslB5iqdL7tg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  sass-embedded-linux-riscv64@1.89.2:
+    resolution: {integrity: sha512-g9nTbnD/3yhOaskeqeBQETbtfDQWRgsjHok6bn7DdAuwBsyrR3JlSFyqKc46pn9Xxd9SQQZU8AzM4IR+sY0A0w==}
+    engines: {node: '>=14.0.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  sass-embedded-linux-x64@1.89.2:
+    resolution: {integrity: sha512-Ax7dKvzncyQzIl4r7012KCMBvJzOz4uwSNoyoM5IV6y5I1f5hEwI25+U4WfuTqdkv42taCMgpjZbh9ERr6JVMQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  sass-embedded-win32-arm64@1.89.2:
+    resolution: {integrity: sha512-j96iJni50ZUsfD6tRxDQE2QSYQ2WrfHxeiyAXf41Kw0V4w5KYR/Sf6rCZQLMTUOHnD16qTMVpQi20LQSqf4WGg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  sass-embedded-win32-x64@1.89.2:
+    resolution: {integrity: sha512-cS2j5ljdkQsb4PaORiClaVYynE9OAPZG/XjbOMxpQmjRIf7UroY4PEIH+Waf+y47PfXFX9SyxhYuw2NIKGbEng==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  sass-embedded@1.89.2:
+    resolution: {integrity: sha512-Ack2K8rc57kCFcYlf3HXpZEJFNUX8xd8DILldksREmYXQkRHI879yy8q4mRDJgrojkySMZqmmmW1NxrFxMsYaA==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
 
   sass-lookup@6.1.0:
     resolution: {integrity: sha512-Zx+lVyoWqXZxHuYWlTA17Z5sczJ6braNT2C7rmClw+c4E7r/n911Zwss3h1uHI9reR5AgHZyNHF7c2+VIp5AUA==}
@@ -5656,6 +5769,14 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  sync-child-process@1.0.2:
+    resolution: {integrity: sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==}
+    engines: {node: '>=16.0.0'}
+
+  sync-message-port@1.1.3:
+    resolution: {integrity: sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg==}
+    engines: {node: '>=16.0.0'}
+
   synckit@0.11.11:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -5948,6 +6069,9 @@ packages:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  varint@6.0.0:
+    resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -5990,6 +6114,15 @@ packages:
     peerDependenciesMeta:
       '@nuxt/kit':
         optional: true
+
+  vite-plugin-sass-dts@1.3.31:
+    resolution: {integrity: sha512-9egcHbUZdnCr2l1g9X2bHl6LjXv2mXb9xWRX3CVXHt/t4Io+HL5dYsBimlY4QImzbSeH26d7Bw6v0NUrQfwEDA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      postcss: ^8
+      prettier: ^2.7 || ^3
+      sass-embedded: ^1.78.0
+      vite: '>=3'
 
   vite-svg-loader@5.1.0:
     resolution: {integrity: sha512-M/wqwtOEjgb956/+m5ZrYT/Iq6Hax0OakWbokj8+9PXOnB7b/4AxESHieEtnNEy7ZpjsjYW1/5nK8fATQMmRxw==}
@@ -6073,8 +6206,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.0.4:
-    resolution: {integrity: sha512-WtR3kPk8vqKYfCK/HGyT47lK/T3FaVyWxaCNuosaHYE8h9/k0lYRZ/PI/+T/z2wP+uuNKmL6z30rOcBboOu/YA==}
+  vue-component-type-helpers@3.0.5:
+    resolution: {integrity: sha512-uoNZaJ+a1/zppa/Vgmi8zIOP2PHXDN2rT8NyF+zQRK6ZG94lNB9prcV0GdLJbY9i9lrD47JOVIH92SaiA7oJ1A==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -6941,6 +7074,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bufbuild/protobuf@2.6.2': {}
 
   '@bundled-es-modules/deepmerge@4.3.1':
     dependencies:
@@ -8087,13 +8222,13 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1))':
+  '@storybook/builder-vite@8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))':
     dependencies:
       '@storybook/csf-plugin': 8.6.14(storybook@8.6.14(prettier@3.6.2))
       browser-assert: 1.2.1
       storybook: 8.6.14(prettier@3.6.2)
       ts-dedent: 2.2.0
-      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
 
   '@storybook/components@8.6.14(storybook@8.6.14(prettier@3.6.2))':
     dependencies:
@@ -8167,15 +8302,15 @@ snapshots:
     dependencies:
       storybook: 8.6.14(prettier@3.6.2)
 
-  '@storybook/vue3-vite@8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))':
+  '@storybook/vue3-vite@8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))':
     dependencies:
-      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1))
+      '@storybook/builder-vite': 8.6.14(storybook@8.6.14(prettier@3.6.2))(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
       '@storybook/vue3': 8.6.14(storybook@8.6.14(prettier@3.6.2))(vue@3.5.18(typescript@5.8.3))
       find-package-json: 1.2.0
       magic-string: 0.30.17
       storybook: 8.6.14(prettier@3.6.2)
       typescript: 5.8.3
-      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
       vue-component-meta: 2.2.12(typescript@5.8.3)
       vue-docgen-api: 4.79.2(vue@3.5.18(typescript@5.8.3))
     transitivePeerDependencies:
@@ -8193,7 +8328,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.18(typescript@5.8.3)
-      vue-component-type-helpers: 3.0.4
+      vue-component-type-helpers: 3.0.5
 
   '@tanstack/virtual-core@3.13.12': {}
 
@@ -8519,10 +8654,10 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  '@vitejs/plugin-vue@6.0.1(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))(vue@3.5.18(typescript@5.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
       vue: 3.5.18(typescript@5.8.3)
 
   '@vitest/coverage-v8@1.6.1(vitest@1.6.1)':
@@ -8540,7 +8675,7 @@ snapshots:
       std-env: 3.9.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@20.19.9)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vitest: 1.6.1(@types/node@20.19.9)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8594,7 +8729,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 1.6.1(@types/node@20.19.9)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vitest: 1.6.1(@types/node@20.19.9)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -9140,6 +9275,8 @@ snapshots:
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
+
+  buffer-builder@0.2.0: {}
 
   buffer-from@1.1.2: {}
 
@@ -11980,6 +12117,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-buffer@5.2.1: {}
 
   safe-regex-test@1.1.0:
@@ -11989,6 +12130,82 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  sass-embedded-android-arm64@1.89.2:
+    optional: true
+
+  sass-embedded-android-arm@1.89.2:
+    optional: true
+
+  sass-embedded-android-riscv64@1.89.2:
+    optional: true
+
+  sass-embedded-android-x64@1.89.2:
+    optional: true
+
+  sass-embedded-darwin-arm64@1.89.2:
+    optional: true
+
+  sass-embedded-darwin-x64@1.89.2:
+    optional: true
+
+  sass-embedded-linux-arm64@1.89.2:
+    optional: true
+
+  sass-embedded-linux-arm@1.89.2:
+    optional: true
+
+  sass-embedded-linux-musl-arm64@1.89.2:
+    optional: true
+
+  sass-embedded-linux-musl-arm@1.89.2:
+    optional: true
+
+  sass-embedded-linux-musl-riscv64@1.89.2:
+    optional: true
+
+  sass-embedded-linux-musl-x64@1.89.2:
+    optional: true
+
+  sass-embedded-linux-riscv64@1.89.2:
+    optional: true
+
+  sass-embedded-linux-x64@1.89.2:
+    optional: true
+
+  sass-embedded-win32-arm64@1.89.2:
+    optional: true
+
+  sass-embedded-win32-x64@1.89.2:
+    optional: true
+
+  sass-embedded@1.89.2:
+    dependencies:
+      '@bufbuild/protobuf': 2.6.2
+      buffer-builder: 0.2.0
+      colorjs.io: 0.5.2
+      immutable: 5.1.3
+      rxjs: 7.8.2
+      supports-color: 8.1.1
+      sync-child-process: 1.0.2
+      varint: 6.0.0
+    optionalDependencies:
+      sass-embedded-android-arm: 1.89.2
+      sass-embedded-android-arm64: 1.89.2
+      sass-embedded-android-riscv64: 1.89.2
+      sass-embedded-android-x64: 1.89.2
+      sass-embedded-darwin-arm64: 1.89.2
+      sass-embedded-darwin-x64: 1.89.2
+      sass-embedded-linux-arm: 1.89.2
+      sass-embedded-linux-arm64: 1.89.2
+      sass-embedded-linux-musl-arm: 1.89.2
+      sass-embedded-linux-musl-arm64: 1.89.2
+      sass-embedded-linux-musl-riscv64: 1.89.2
+      sass-embedded-linux-musl-x64: 1.89.2
+      sass-embedded-linux-riscv64: 1.89.2
+      sass-embedded-linux-x64: 1.89.2
+      sass-embedded-win32-arm64: 1.89.2
+      sass-embedded-win32-x64: 1.89.2
 
   sass-lookup@6.1.0:
     dependencies:
@@ -12370,6 +12587,12 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  sync-child-process@1.0.2:
+    dependencies:
+      sync-message-port: 1.1.3
+
+  sync-message-port@1.1.3: {}
+
   synckit@0.11.11:
     dependencies:
       '@pkgr/core': 0.2.9
@@ -12641,6 +12864,8 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
+  varint@6.0.0: {}
+
   vary@1.1.2: {}
 
   vee-validate@4.15.1(vue@3.5.18(typescript@5.8.3)):
@@ -12649,23 +12874,23 @@ snapshots:
       type-fest: 4.41.0
       vue: 3.5.18(typescript@5.8.3)
 
-  vite-dev-rpc@1.1.0(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)):
+  vite-dev-rpc@1.1.0(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)):
     dependencies:
       birpc: 2.5.0
-      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
-      vite-hot-client: 2.1.0(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1))
+      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
+      vite-hot-client: 2.1.0(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
 
-  vite-hot-client@2.1.0(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)):
+  vite-hot-client@2.1.0(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)):
     dependencies:
-      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
 
-  vite-node@1.6.1(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1):
+  vite-node@1.6.1(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -12677,13 +12902,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.6.1(@types/node@22.17.0)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1):
+  vite-node@1.6.1(@types/node@22.17.0)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.19(@types/node@22.17.0)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vite: 5.4.19(@types/node@22.17.0)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -12695,7 +12920,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@4.5.4(@types/node@20.19.9)(rollup@4.46.2)(typescript@5.8.3)(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)):
+  vite-plugin-dts@4.5.4(@types/node@20.19.9)(rollup@4.46.2)(typescript@5.8.3)(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)):
     dependencies:
       '@microsoft/api-extractor': 7.52.9(@types/node@20.19.9)
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
@@ -12708,13 +12933,13 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.8.3
     optionalDependencies:
-      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-inspect@11.3.2(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)):
+  vite-plugin-inspect@11.3.2(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)):
     dependencies:
       ansis: 4.1.0
       debug: 4.4.1
@@ -12724,17 +12949,25 @@ snapshots:
       perfect-debounce: 1.0.0
       sirv: 3.0.1
       unplugin-utils: 0.2.4
-      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
-      vite-dev-rpc: 1.1.0(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1))
+      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
+      vite-dev-rpc: 1.1.0(vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
     transitivePeerDependencies:
       - supports-color
+
+  vite-plugin-sass-dts@1.3.31(postcss@8.5.6)(prettier@3.6.2)(sass-embedded@1.89.2)(vite@5.4.19(@types/node@22.17.0)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)):
+    dependencies:
+      postcss: 8.5.6
+      postcss-js: 4.0.1(postcss@8.5.6)
+      prettier: 3.6.2
+      sass-embedded: 1.89.2
+      vite: 5.4.19(@types/node@22.17.0)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
 
   vite-svg-loader@5.1.0(vue@3.5.18(typescript@5.8.3)):
     dependencies:
       svgo: 3.3.2
       vue: 3.5.18(typescript@5.8.3)
 
-  vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1):
+  vite@5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -12744,9 +12977,10 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.27.0
       sass: 1.89.2
+      sass-embedded: 1.89.2
       terser: 5.43.1
 
-  vite@5.4.19(@types/node@22.17.0)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1):
+  vite@5.4.19(@types/node@22.17.0)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -12756,9 +12990,10 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.27.0
       sass: 1.89.2
+      sass-embedded: 1.89.2
       terser: 5.43.1
 
-  vitest@1.6.1(@types/node@20.19.9)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1):
+  vitest@1.6.1(@types/node@20.19.9)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -12777,8 +13012,8 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
-      vite-node: 1.6.1(@types/node@20.19.9)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vite: 5.4.19(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
+      vite-node: 1.6.1(@types/node@20.19.9)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.9
@@ -12794,7 +13029,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.1(@types/node@22.17.0)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1):
+  vitest@1.6.1(@types/node@22.17.0)(@vitest/ui@1.6.1)(jsdom@24.1.3)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -12813,8 +13048,8 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.19(@types/node@22.17.0)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
-      vite-node: 1.6.1(@types/node@22.17.0)(lightningcss@1.27.0)(sass@1.89.2)(terser@5.43.1)
+      vite: 5.4.19(@types/node@22.17.0)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
+      vite-node: 1.6.1(@types/node@22.17.0)(lightningcss@1.27.0)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.17.0
@@ -12847,7 +13082,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.0.4: {}
+  vue-component-type-helpers@3.0.5: {}
 
   vue-demi@0.14.10(vue@3.5.18(typescript@5.8.3)):
     dependencies:


### PR DESCRIPTION
### 오류 사항

- packages/ui의 dist 디렉토리에 SCSS 파일이 포함되지 않았음
- 이에 따라 다른 패키지나 앱에서 UI 컴포넌트 사용 시 스타일이 정상적으로 적용되지 않는 오류 발생

---

### 주요 변경사항

- **UI 패키지 SCSS 번들링 구조 개선**
  - `packages/ui/src/styles/index.scss` 신규 생성: 모든 컴포넌트 SCSS를 한 번에 import하여 CSS 번들로 컴파일
  - `src/index.ts`에서 `style.css` 대신 `styles/index.scss`를 import하도록 변경
  - Vite 빌드 시 `dist/style.css`로 모든 컴포넌트 스타일이 하나로 번들링
  - 다른 패키지/앱에서 `@template/ui/style.css` import 시 모든 UI 컴포넌트의 스타일이 정상 적용되도록 수정

- **exports 구조 개선**
  - `packages/ui/package.json`의 `exports`에 `"./style.css": "./dist/style.css"` 추가
  - 앱에서 `@template/ui/style.css`로 글로벌 스타일 import 가능

- **앱별 글로벌 스타일 적용**
  - `apps/desktop`, `apps/mobile`, `apps/moda-desktop` 각 main.ts에서 `@template/ui/style.css` import 추가
  - 모든 앱에서 UI 컴포넌트의 SCSS 기반 스타일이 정상적으로 적용됨

- **의존성 및 빌드 설정 정리**
  - `vite.config.ts`에서 CSS 번들 옵션 명확화
  - `vite-plugin-sass-dts` 등 devDependencies 정리

### 마이그레이션/참고

- Sass 모듈 시스템(@use)만 사용, @import 사용부 제거
- Storybook/Vite 환경에서 SCSS 스타일 적용 및 번들 구조 일관성 확보
- 참고: [Sass 공식 @import 폐지 안내](https://sass-lang.com/documentation/breaking-changes/import/)