### PR TITLE
feat: BaseProgressBar 컴포넌트 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ $RECYCLE.BIN/
 .nfs*
 
 # IDE 및 에디터 파일
-.vscode/
 .idea/
 *.swp
 *.swo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,9 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[scss]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "files.associations": {
     "*.css": "tailwindcss"
   },

--- a/packages/ui/src/components/BaseProgressBar/BaseProgressBar.scss
+++ b/packages/ui/src/components/BaseProgressBar/BaseProgressBar.scss
@@ -16,8 +16,9 @@
 
   &__fill {
     height: 100%;
-    border-radius: 999px;
-    transition: width 0.3s ease, background-color 0.3s ease;
+    transition:
+      width 0.3s ease,
+      background-color 0.3s ease;
   }
 
   /* 라벨 */
@@ -31,4 +32,4 @@
     flex-shrink: 0;
     transition: color 0.3s ease;
   }
-} 
+}

--- a/packages/ui/src/components/BaseProgressBar/BaseProgressBar.vue
+++ b/packages/ui/src/components/BaseProgressBar/BaseProgressBar.vue
@@ -9,7 +9,10 @@
       <div
         class="base-progress-bar__fill"
         :class="progressColorClass"
-        :style="{ width: `${progressPercentage}%` }"
+        :style="{
+          width: `${progressPercentage}%`,
+          borderRadius: props.variant === 'performance' ? '999px 0 0 999px' : '999px',
+        }"
       />
     </div>
 
@@ -34,7 +37,7 @@ interface Props {
   /** 최대값 */
   max?: number;
   /** 진행바 변형 */
-  variant?: 'default' | 'password-strength';
+  variant?: 'default' | 'password-strength' | 'performance';
   /** 라벨 표시 여부 */
   showLabel?: boolean;
   /** 커스텀 라벨 */
@@ -52,7 +55,7 @@ const props = withDefaults(defineProps<Props>(), {
   max: 100,
   variant: 'default',
   showLabel: false,
-  trackColorClass: 'bg-common-light-gray-ea',
+  trackColorClass: 'bg-bg-bg-surface',
   fillColorClass: 'bg-blue-blue800-deep',
 });
 
@@ -109,6 +112,8 @@ const label = computed(() => {
   if (props.variant === 'password-strength') {
     const labels = ['매우 약함', '약함', '보통', '강함', '매우 강함'];
     return labels[props.strengthScore || 0] || labels[0];
+  } else if (props.variant === 'performance') {
+    return;
   }
 
   return `${Math.round(progressPercentage.value)}%`;

--- a/packages/ui/src/components/BaseProgressBar/__stories__/BaseProgressBar.stories.ts
+++ b/packages/ui/src/components/BaseProgressBar/__stories__/BaseProgressBar.stories.ts
@@ -26,7 +26,7 @@ const meta: Meta<typeof BaseProgressBar> = {
     },
     variant: {
       control: { type: 'select' },
-      options: ['default', 'password-strength'],
+      options: ['default', 'password-strength','performance'],
       description: '진행바 변형'
     },
     showLabel: {
@@ -124,4 +124,17 @@ export const PasswordStrengthCustomLabel: Story = {
     showLabel: true,
     label: '보안 수준'
   }
-} 
+}
+
+// 성과 진행바
+export const Performance: Story = {
+  args: {
+    variant: 'performance',
+    value: 80,
+    max: 100,
+    showLabel: false,
+    label: '성과',
+    fillColorClass: 'bg-blue-blue800-deep',
+    trackColorClass: 'bg-red-red800'
+  }
+}


### PR DESCRIPTION
- 성과 진행바 표시를 위한 'performance' varient 추가
- 진행바 기본 배경 props : 시맨틱 -> 컴포넌트 클래스로 변경

## 변경사항 요약
성과 진행바 표시를 위한 'performance' variant 추가
진행바 기본 배경 props 개선: 시맨틱 클래스에서 컴포넌트 클래스로 변경
CSS 스타일 최적화: transition 속성 가독성 개선

## 🔧 주요 변경사항
1. 새로운 variant 추가
performance variant 추가로 성과 지표 표시에 특화된 진행바 지원
성과 진행바에 적합한 스타일링 적용
2. Props 개선
진행바 기본 배경을 시맨틱 클래스에서 컴포넌트 클래스로 변경
더 명확하고 일관된 스타일링 시스템 구축
3. 코드 품질 개선
CSS transition 속성의 가독성 향상
멀티라인 포맷팅으로 유지보수성 개선

## 🎯 사용 예시
```
<!-- 성과 진행바 사용 예시 -->
<BaseProgressBar 
  variant="performance"
  :value="80"
  :max="100"
  fillColorClass="bg-blue-blue800-deep"
  trackColorClass="bg-red-red800"
/>
```
<img width="2149" height="502" alt="image" src="https://github.com/user-attachments/assets/5d43e199-e48e-44d4-807f-978378f4a2ac" />


## ✅ 테스트 완료
- [x] 성과 진행바 variant 정상 동작 확인
- [x] 기존 variant들과의 호환성 검증
- [x] CSS 스타일 변경사항 적용 확인