### PR TITLE
feat: BasePaginationJoin 컴포넌트 리팩토링

### DIFF
--- a/packages/ui/src/components/BasePagination/BasePaginationJoin.scss
+++ b/packages/ui/src/components/BasePagination/BasePaginationJoin.scss
@@ -28,7 +28,9 @@
 }
 
 .pagination-join-dot-inactive {
-  background-color: var(--background-bg-surface-muted); // #dadbdd → var(--background-bg-surface-muted)
+  background-color: var(
+    --background-bg-surface-muted
+  ); // #dadbdd → var(--background-bg-surface-muted)
 }
 
 // 선 스타일 (활성)
@@ -38,5 +40,7 @@
 }
 
 .pagination-join-line-active {
-  background-color: var(--button-primary-background); // #ffc300 → var(--button-primary-background)
+  background-color: var(
+    --base-colors-primary-primary800
+  ); // #ffc300 → var(--base-colors-primary-primary800)
 }


### PR DESCRIPTION
- 활성화 영역 색상 : 컴포넌트 -> 시맨틱 클래스로 변경

## 🎨 변경사항
### BasePaginationJoin 컴포넌트 색상 리팩토링
- 컴포넌트별 색상 정의에서 피그마에서 잘못 네이밍된 요소 시맨틱 CSS 변수로 변경


## 📋 체크리스트
- [x] 기존 기능 동작 확인
