### PR TITLE
개인 회원가입 화면 퍼블리싱

### DIFF
--- a/apps/sample-desktop/src/components/auth/AuthContent.vue
+++ b/apps/sample-desktop/src/components/auth/AuthContent.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="gap-size-48 flex w-[460px] flex-col justify-center px-[50px] pb-[60px] pt-[50px]">
+  <div
+    class="gap-size-48 bg-neutral-neutral000 border-bg-outline m-auto flex w-[460px] flex-col rounded-md border px-[50px] pb-[60px] pt-[50px]"
+  >
     <slot name="header" />
     <div v-if="props.title">
       <div>

--- a/apps/sample-desktop/src/components/auth/AuthContent.vue
+++ b/apps/sample-desktop/src/components/auth/AuthContent.vue
@@ -7,7 +7,7 @@
       </div>
       <div class="mt-6">
         <h2 class="text-font-24 tracking-3 font-semibold">{{ props.title }}</h2>
-        <p class="text-font-16 tracking-3 mt-3">{{ props.description }}</p>
+        <p class="text-font-16 tracking-3 mt-3" v-html="props.description"></p>
       </div>
     </div>
     <slot name="content" />

--- a/apps/sample-desktop/src/components/auth/common/CheckBoxLabel.vue
+++ b/apps/sample-desktop/src/components/auth/common/CheckBoxLabel.vue
@@ -1,0 +1,12 @@
+<template>
+  <div class="gap-size-4 flex items-center">
+    <BaseCheckbox v-model="isChecked" />
+    <slot> </slot>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { BaseCheckbox } from '@template/ui';
+
+const isChecked = defineModel<boolean>('isChecked', { required: true });
+</script>

--- a/apps/sample-desktop/src/components/auth/findId/AuthFindId.vue
+++ b/apps/sample-desktop/src/components/auth/findId/AuthFindId.vue
@@ -27,7 +27,14 @@
           </FormField>
         </div>
         <div class="mt-[33px]">
-          <BaseButton size="large" label="다음" variant="contained" color="primary" full-width />
+          <BaseButton
+            size="large"
+            label="다음"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 1"
+          />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/login/BaseLogin.vue
+++ b/apps/sample-desktop/src/components/auth/login/BaseLogin.vue
@@ -1,0 +1,46 @@
+<template>
+  <AuthContent title="개인회원 가입">
+    <template #content>
+      <div>
+        <div class="gap-size-16 flex flex-col">
+          <FormField label="이메일주소(ID)">
+            <BaseInput size="md" placeholder="example@email.com" />
+          </FormField>
+          <FormField label="비밀번호">
+            <BaseInput size="md" placeholder="영문+숫자, 8~16자리 이상" />
+          </FormField>
+          <div class="flex items-center justify-between">
+            <div>
+              <CheckBoxLabel v-model:isChecked="isChecked">
+                <span class="text-font-13">아이디 저장</span>
+              </CheckBoxLabel>
+            </div>
+            <div class="gap-size-12 text-font-13 flex items-center">
+              <a class="cursor-pointer underline" href="/auth/find-id">아이디 찾기</a>
+              <span class="text-font-12 text-default-muted">|</span>
+              <a class="cursor-pointer underline" href="/auth/reset-password">비밀번호 재설정</a>
+            </div>
+          </div>
+        </div>
+        <div class="mt-[33px]">
+          <BaseButton size="regular" label="로그인" variant="primary" />
+        </div>
+        <div class="mt-6 flex justify-center">
+          <a class="font-regular cursor-pointer text-[13px] underline" href="/auth/sign-up"
+            >가입하기</a
+          >
+        </div>
+      </div>
+    </template>
+  </AuthContent>
+</template>
+
+<script lang="ts" setup>
+import CheckBoxLabel from '@/components/auth/common/CheckBoxLabel.vue';
+import FormField from '@/components/auth/common/FormField.vue';
+import AuthContent from '@/components/auth/AuthContent.vue';
+import { BaseInput, BaseButton } from '@template/ui';
+import { ref } from 'vue';
+
+const isChecked = ref<boolean>(false);
+</script>

--- a/apps/sample-desktop/src/components/auth/login/BaseLogin.vue
+++ b/apps/sample-desktop/src/components/auth/login/BaseLogin.vue
@@ -23,7 +23,7 @@
           </div>
         </div>
         <div class="mt-[33px]">
-          <BaseButton size="regular" label="로그인" variant="primary" />
+          <BaseButton size="large" label="로그인" variant="contained" color="primary" full-width />
         </div>
         <div class="mt-6 flex justify-center">
           <a class="font-regular cursor-pointer text-[13px] underline" href="/auth/sign-up"

--- a/apps/sample-desktop/src/components/auth/resetPassword/ResetPasswordComplete.vue
+++ b/apps/sample-desktop/src/components/auth/resetPassword/ResetPasswordComplete.vue
@@ -10,7 +10,7 @@
           <p>다시 로그인해주세요</p>
         </div>
       </div>
-      <div><BaseButton label="확인" /></div>
+      <div><BaseButton label="확인" full-width /></div>
     </template>
   </AuthContent>
 </template>

--- a/apps/sample-desktop/src/components/auth/resetPassword/ResetPasswordEmailAuth.vue
+++ b/apps/sample-desktop/src/components/auth/resetPassword/ResetPasswordEmailAuth.vue
@@ -35,8 +35,15 @@
         </div>
 
         <div class="gap-size-12 mt-[33px] flex items-center">
-          <BaseButton size="regular" label="인증번호 전송" variant="primary" @click="step = 2" />
-          <BaseButton size="regular" label="취소" variant="disabled" />
+          <BaseButton
+            size="large"
+            label="인증번호 전송"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 2"
+          />
+          <BaseButton size="large" label="취소" variant="contained" color="cancel" full-width />
         </div>
         <div class="mt-size-16 flex items-center justify-center">
           <span class="text-font-14 cursor-pointer font-medium underline">인증번호 재전송</span>

--- a/apps/sample-desktop/src/components/auth/resetPassword/ResetPasswordEmailForm.vue
+++ b/apps/sample-desktop/src/components/auth/resetPassword/ResetPasswordEmailForm.vue
@@ -22,7 +22,14 @@
           </FormField>
         </div>
         <div class="mt-[33px]">
-          <BaseButton size="regular" label="다음" variant="primary" @click="step = 1" />
+          <BaseButton
+            size="large"
+            label="다음"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 1"
+          />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/resetPassword/ResetPasswordNewPassword.vue
+++ b/apps/sample-desktop/src/components/auth/resetPassword/ResetPasswordNewPassword.vue
@@ -35,7 +35,14 @@
           </FormField>
         </div>
         <div class="gap-size-12 mt-[33px] flex items-center">
-          <BaseButton size="regular" label="다음" variant="primary" @click="step = 3" />
+          <BaseButton
+            size="large"
+            label="다음"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 3"
+          />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/signup/SignUpIntro.vue
+++ b/apps/sample-desktop/src/components/auth/signup/SignUpIntro.vue
@@ -40,6 +40,8 @@ const router = useRouter();
 const type = ref<'individual' | 'corporation' | null>(null);
 
 const onClickNext = () => {
+  if (type.value) {
+  }
   if (type.value === 'individual') {
     router.push({ name: 'individual-sign-up' });
   } else if (type.value === 'corporation') {

--- a/apps/sample-desktop/src/components/auth/signup/SignUpIntro.vue
+++ b/apps/sample-desktop/src/components/auth/signup/SignUpIntro.vue
@@ -1,10 +1,30 @@
 <template>
   <AuthContent title="회원가입" description="개인회원과 법인회원 중 선택해주세요.">
     <template #content>
-      <div class="mt-12">버튼 영역 개인|법인</div>
-      <div class="mt-[33px] w-[360px]">버튼 영역 다음</div>
-      <div class="flex justify-center mt-6">
-        <a class="underline text-[13px] font-regular cursor-pointer">이미 아이디가 있어요</a>
+      <div class="gap-size-12 flex items-center justify-center">
+        <BaseButton
+          class="h-[80px]"
+          :variant="type === 'individual' ? 'light-solid' : 'outline'"
+          label="개인회원"
+          @click="type = 'individual'"
+        />
+        <BaseButton
+          class="h-[80px]"
+          :variant="type === 'corporation' ? 'light-solid' : 'outline'"
+          label="법인회원"
+          @click="type = 'corporation'"
+        />
+      </div>
+      <div class="mt-[33px] w-[360px]">
+        <BaseButton
+          size="regular"
+          label="다음"
+          :variant="type ? 'primary' : 'disabled'"
+          @click="onClickNext"
+        />
+      </div>
+      <div class="mt-6 flex justify-center">
+        <a class="font-regular cursor-pointer text-[13px] underline">이미 아이디가 있어요</a>
       </div>
     </template>
   </AuthContent>
@@ -12,4 +32,18 @@
 
 <script lang="ts" setup>
 import AuthContent from '@/components/auth/AuthContent.vue';
+import { BaseButton } from '@template/ui';
+import { useRouter } from 'vue-router';
+import { ref } from 'vue';
+
+const router = useRouter();
+const type = ref<'individual' | 'corporation' | null>(null);
+
+const onClickNext = () => {
+  if (type.value === 'individual') {
+    router.push({ name: 'individual-sign-up' });
+  } else if (type.value === 'corporation') {
+    router.push({ name: 'corporate-sign-up' });
+  }
+};
 </script>

--- a/apps/sample-desktop/src/components/auth/signup/SignUpIntro.vue
+++ b/apps/sample-desktop/src/components/auth/signup/SignUpIntro.vue
@@ -1,30 +1,36 @@
 <template>
   <AuthContent title="회원가입" description="개인회원과 법인회원 중 선택해주세요.">
     <template #content>
-      <div class="gap-size-12 flex items-center justify-center">
-        <BaseButton
-          class="h-[80px]"
-          :variant="type === 'individual' ? 'light-solid' : 'outline'"
-          label="개인회원"
-          @click="type = 'individual'"
-        />
-        <BaseButton
-          class="h-[80px]"
-          :variant="type === 'corporation' ? 'light-solid' : 'outline'"
-          label="법인회원"
-          @click="type = 'corporation'"
-        />
-      </div>
-      <div class="mt-[33px] w-[360px]">
-        <BaseButton
-          size="regular"
-          label="다음"
-          :variant="type ? 'primary' : 'disabled'"
-          @click="onClickNext"
-        />
-      </div>
-      <div class="mt-6 flex justify-center">
-        <a class="font-regular cursor-pointer text-[13px] underline">이미 아이디가 있어요</a>
+      <div>
+        <div class="gap-size-12 flex items-center justify-center">
+          <BaseButton
+            class="h-[80px]"
+            :variant="type === 'individual' ? 'contained' : 'outlined'"
+            label="개인회원"
+            full-width
+            @click="type = 'individual'"
+          />
+          <BaseButton
+            class="h-[80px]"
+            :variant="type === 'corporation' ? 'contained' : 'outlined'"
+            label="법인회원"
+            full-width
+            @click="type = 'corporation'"
+          />
+        </div>
+        <div class="mt-[33px] w-[360px]">
+          <BaseButton
+            size="large"
+            label="다음"
+            variant="contained"
+            :disabled="!type"
+            full-width
+            @click="onClickNext"
+          />
+        </div>
+        <div class="mt-6 flex justify-center">
+          <a class="font-regular cursor-pointer text-[13px] underline">이미 아이디가 있어요</a>
+        </div>
       </div>
     </template>
   </AuthContent>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualDocument.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualDocument.vue
@@ -24,8 +24,8 @@
             <BaseFileUploadButton status="hover" />
           </div>
         </div>
-        <div class="flex flex-col">
-          <BaseButton size="regular" label="제출하기" variant="primary" @click="step = 6" />
+        <div class="">
+          <BaseButton size="regular" label="제출하기" variant="primary" @click="step = 7" />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualDocument.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualDocument.vue
@@ -25,7 +25,14 @@
           </div>
         </div>
         <div class="">
-          <BaseButton size="regular" label="제출하기" variant="primary" @click="step = 7" />
+          <BaseButton
+            size="large"
+            label="제출하기"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 7"
+          />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualDocument.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualDocument.vue
@@ -1,0 +1,55 @@
+<template>
+  <AuthContent title="개인회원 가입" :description="description">
+    <template #header>
+      <div class="flex items-center justify-between">
+        <BaseIcon name="arrow-backward" size="md" />
+        <BasePaginationJoin :count="4" :current="3" />
+      </div>
+    </template>
+    <template #content>
+      <div class="flex flex-col gap-[33px]">
+        <FormField label="신분증 (주민증록증 또는 운전면허증)*">
+          <BaseFileUploadButton status="hover" />
+        </FormField>
+        <div>
+          <div class="mt-size-12 gap-size-4 flex items-center">
+            <span class="text-font-16 font-semibold">신분증의 주소가 현 주소와 다른가요?</span>
+            <BaseCheckbox v-model="isChecked" />
+          </div>
+          <div v-if="isChecked" class="gap-size-12 mt-size-4 flex flex-col">
+            <span class="text-font-14">
+              <span class="font-medium">주민등록 초본(영문)</span> 또는
+              <span class="font-medium">관공서 납부영수증</span>을 제출해주세요.
+            </span>
+            <BaseFileUploadButton status="hover" />
+          </div>
+        </div>
+        <div class="flex flex-col">
+          <BaseButton size="regular" label="제출하기" variant="primary" @click="step = 6" />
+        </div>
+      </div>
+    </template>
+  </AuthContent>
+</template>
+<script lang="ts" setup>
+import {
+  BaseIcon,
+  BasePaginationJoin,
+  BaseButton,
+  BaseFileUploadButton,
+  BaseCheckbox,
+} from '@template/ui';
+import FormField from '@/components/auth/common/FormField.vue';
+import AuthContent from '@/components/auth/AuthContent.vue';
+import { ref } from 'vue';
+
+const step = defineModel<number>('step', { required: true });
+
+const isChecked = ref<boolean>(false);
+
+const description = `
+    가입에 필요한 서류를 제출해주세요.<br/>
+    관리자 확인 후 <span class='text-red font-medium'>승인 알림</span>을 보내드립니다.
+    <p class='mt-size-12 text-font-12 text-blue'>&#8251; 파일형식: .png, .jpg, .pdf / 파일 사이즈 300KB 미만</p>
+    `;
+</script>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualEmailAuth.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualEmailAuth.vue
@@ -32,8 +32,21 @@
         </div>
 
         <div class="gap-size-12 mt-[33px] flex items-center">
-          <BaseButton size="regular" label="인증 메일 전송" variant="outline" @click="step = 4" />
-          <BaseButton size="regular" label="다음" variant="disabled" />
+          <BaseButton
+            size="large"
+            label="인증 메일 재전송"
+            variant="outlined"
+            color="primary"
+            full-width
+          />
+          <BaseButton
+            size="large"
+            label="다음"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 4"
+          />
         </div>
         <div class="mt-size-16 flex items-center justify-center">
           <span class="text-font-14 text-default-muted cursor-pointer font-medium underline"

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualEmailAuth.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualEmailAuth.vue
@@ -1,0 +1,52 @@
+<template>
+  <AuthContent
+    title="개인회원 가입"
+    description="메일함에서 인증 메일을 확인해주세요. <br/> 인증번호 6자리를 입력하면 회원가입이 완료돼요."
+  >
+    <template #header>
+      <div class="flex items-center justify-between">
+        <BaseIcon name="arrow-backward" size="md" />
+        <BasePaginationJoin :count="4" :current="2" />
+      </div>
+    </template>
+    <template #content>
+      <div>
+        <div>
+          <div class="gap-size-12 flex items-center">
+            <BaseInput size="md" />
+            <BaseInput size="md" />
+            <BaseInput size="md" />
+            <BaseInput size="md" />
+            <BaseInput size="md" />
+            <BaseInput size="md" />
+          </div>
+          <div class="mt-size-8 flex items-center justify-end">
+            <span class="text-font-12 text-red tracking-3">남은 시간: 10:00</span>
+          </div>
+        </div>
+        <div
+          class="mt-size-24 border-primary-primary800 bg-primary-primary100 p-size-8 text-font-12 rounded-md border"
+        >
+          <p>인증번호는 6자리 숫자이며, 유효기간은 10분입니다.</p>
+          <p>메일이 도착하지 않았다면 스팸함을 확인해주세요.</p>
+        </div>
+
+        <div class="gap-size-12 mt-[33px] flex items-center">
+          <BaseButton size="regular" label="인증 메일 전송" variant="outline" @click="step = 4" />
+          <BaseButton size="regular" label="다음" variant="disabled" />
+        </div>
+        <div class="mt-size-16 flex items-center justify-center">
+          <span class="text-font-14 text-default-muted cursor-pointer font-medium underline"
+            >다른 이메일주소로 변경하기</span
+          >
+        </div>
+      </div>
+    </template>
+  </AuthContent>
+</template>
+
+<script lang="ts" setup>
+import { BaseIcon, BasePaginationJoin, BaseInput, BaseButton } from '@template/ui';
+import AuthContent from '@/components/auth/AuthContent.vue';
+const step = defineModel<number>('step', { required: true });
+</script>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualEmailForm.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualEmailForm.vue
@@ -19,7 +19,14 @@
           </FormField>
         </div>
         <div class="mt-[33px]">
-          <BaseButton size="regular" label="다음" variant="primary" @click="step = 3" />
+          <BaseButton
+            size="large"
+            label="다음"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 3"
+          />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualEmailForm.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualEmailForm.vue
@@ -1,0 +1,35 @@
+<template>
+  <AuthContent title="개인회원 가입" description="아이디로 사용할 이메일주소를 입력해주세요.">
+    <template #header>
+      <div class="flex items-center justify-between">
+        <BaseIcon name="arrow-backward" size="md" />
+        <BasePaginationJoin :count="4" :current="2" />
+      </div>
+    </template>
+    <template #content>
+      <div>
+        <div class="gap-size-16 flex flex-col">
+          <FormField label="이메일주소(ID)">
+            <BaseInput
+              size="md"
+              placeholder="example@email.com"
+              errorMessage="이메일 형식이 올바르지 않아요"
+              :error="true"
+            />
+          </FormField>
+        </div>
+        <div class="mt-[33px]">
+          <BaseButton size="regular" label="다음" variant="primary" @click="step = 3" />
+        </div>
+      </div>
+    </template>
+  </AuthContent>
+</template>
+
+<script lang="ts" setup>
+import { BaseIcon, BasePaginationJoin, BaseInput, BaseButton } from '@template/ui';
+import FormField from '@/components/auth/common/FormField.vue';
+import AuthContent from '@/components/auth/AuthContent.vue';
+
+const step = defineModel<number>('step', { required: true });
+</script>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualInfo.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualInfo.vue
@@ -1,15 +1,55 @@
 <template>
   <AuthContent title="개인회원 가입" description="정보를 입력해주세요.">
     <template #header>
-      <div class="mb-12">탑 버튼 영역</div>
+      <div class="flex items-center justify-between">
+        <BaseIcon name="arrow-backward" size="md" />
+        <BasePaginationJoin :count="4" :current="3" />
+      </div>
     </template>
     <template #content>
-      <div class="mt-[33px] w-[360px]">버튼 영역 인증완료</div>
-      <div class="mt-[33px] w-[360px] h-[676px]">개인정보 입력 영역</div>
-      <div class="mt-[33px] w-[360px]">버튼 영역 다음</div>
+      <div>
+        <div class="gap-size-16 flex flex-col">
+          <FormField label="이름(한글)">
+            <BaseInput size="md" disabled />
+          </FormField>
+          <FormField label="휴대폰번호">
+            <BaseInput size="md" disabled />
+          </FormField>
+          <FormField label="생년월일">
+            <BaseInput size="md" disabled />
+          </FormField>
+          <div class="gap-size-8 flex items-center">
+            <FormField label="이름(영문)">
+              <BaseInput size="md" placeholder="예) GILDONG" />
+            </FormField>
+            <FormField label="성(영문)">
+              <BaseInput size="md" placeholder="예) HONG" />
+            </FormField>
+          </div>
+          <FormField label="거주지 주소(한글)">
+            <div class="gap-size-8 flex flex-col">
+              <BaseInput size="md" placeholder="주소 검색" />
+              <BaseInput size="md" placeholder="상세주소" />
+            </div>
+          </FormField>
+          <FormField label="거주지 주소(영문)">
+            <div class="gap-size-8 flex flex-col">
+              <BaseInput size="md" placeholder="주소 검색" />
+              <BaseInput size="md" placeholder="상세주소" />
+            </div>
+          </FormField>
+        </div>
+        <div class="mt-[33px] w-[360px]">
+          <BaseButton size="regular" label="다음" variant="primary" @click="step = 2" />
+        </div>
+      </div>
     </template>
   </AuthContent>
 </template>
 <script lang="ts" setup>
+import { BaseIcon, BasePaginationJoin, BaseButton, BaseInput } from '@template/ui';
+import FormField from '@/components/auth/common/FormField.vue';
 import AuthContent from '@/components/auth/AuthContent.vue';
+
+const step = defineModel<number>('step', { required: true });
 </script>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualInfo.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualInfo.vue
@@ -40,7 +40,14 @@
           </FormField>
         </div>
         <div class="mt-[33px] w-[360px]">
-          <BaseButton size="regular" label="다음" variant="primary" @click="step = 6" />
+          <BaseButton
+            size="large"
+            label="다음"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 6"
+          />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualInfo.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualInfo.vue
@@ -40,7 +40,7 @@
           </FormField>
         </div>
         <div class="mt-[33px] w-[360px]">
-          <BaseButton size="regular" label="다음" variant="primary" @click="step = 2" />
+          <BaseButton size="regular" label="다음" variant="primary" @click="step = 6" />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualPhone.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualPhone.vue
@@ -8,9 +8,10 @@
     </template>
     <template #content>
       <div>
-        <div class="gap-size-12 flex flex-col">
-          <BaseButton size="regular" label="휴대폰 본인인증" variant="red" />
+        <div class="gap-size-12">
+          <BaseButton v-if="!status" size="regular" label="휴대폰 본인인증" variant="red" />
           <BaseButton
+            v-else
             size="regular"
             label="인증완료"
             variant="green-solid"
@@ -27,6 +28,8 @@
 <script lang="ts" setup>
 import { BaseIcon, BasePaginationJoin, BaseButton } from '@template/ui';
 import AuthContent from '@/components/auth/AuthContent.vue';
+import { ref } from 'vue';
 
 const step = defineModel<number>('step', { required: true });
+const status = ref<boolean>(false);
 </script>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualPhone.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualPhone.vue
@@ -1,14 +1,32 @@
 <template>
   <AuthContent title="개인회원 가입" description="서비스 이용을 위해 먼저 본인인증을 해주세요.">
     <template #header>
-      <div class="mb-12">탑 버튼 영역</div>
+      <div class="flex items-center justify-between">
+        <BaseIcon name="arrow-backward" size="md" />
+        <BasePaginationJoin :count="4" :current="1" />
+      </div>
     </template>
     <template #content>
-      <div class="mt-[33px] w-[360px]">버튼 영역 휴대폰 본인인증</div>
-      <div class="mt-[33px] w-[360px]">버튼 영역 다음</div>
+      <div>
+        <div class="gap-size-12 flex flex-col">
+          <BaseButton size="regular" label="휴대폰 본인인증" variant="red" />
+          <BaseButton
+            size="regular"
+            label="인증완료"
+            variant="green-solid"
+            :rightIcon="{ name: 'arrow-right-thin' }"
+          />
+        </div>
+        <div class="mt-[33px] flex flex-col">
+          <BaseButton size="regular" label="다음" variant="primary" @click="step = 2" />
+        </div>
+      </div>
     </template>
   </AuthContent>
 </template>
 <script lang="ts" setup>
+import { BaseIcon, BasePaginationJoin, BaseButton } from '@template/ui';
 import AuthContent from '@/components/auth/AuthContent.vue';
+
+const step = defineModel<number>('step', { required: true });
 </script>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualPhone.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualPhone.vue
@@ -9,17 +9,33 @@
     <template #content>
       <div>
         <div class="gap-size-12">
-          <BaseButton v-if="!status" size="regular" label="휴대폰 본인인증" variant="red" />
+          <BaseButton
+            v-if="status"
+            size="large"
+            label="휴대폰 본인인증"
+            variant="outlined"
+            color="red"
+            full-width
+          />
           <BaseButton
             v-else
-            size="regular"
+            size="large"
             label="인증완료"
-            variant="green-solid"
+            variant="outlined"
+            color="green"
+            full-width
             :rightIcon="{ name: 'arrow-right-thin' }"
           />
         </div>
         <div class="mt-[33px] flex flex-col">
-          <BaseButton size="regular" label="다음" variant="primary" @click="step = 2" />
+          <BaseButton
+            size="large"
+            label="다음"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 2"
+          />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualSetPassword.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualSetPassword.vue
@@ -1,0 +1,59 @@
+<template>
+  <AuthContent title="개인회원 가입" description="비밀번호를 설정해주세요.">
+    <template #header>
+      <div class="flex items-center justify-between">
+        <BaseIcon name="arrow-backward" size="md" />
+        <BasePaginationJoin :count="3" :current="2" />
+      </div>
+    </template>
+    <template #content>
+      <div>
+        <div class="gap-size-16 flex flex-col">
+          <FormField label="비밀번호">
+            <BaseInput
+              v-model="state.password"
+              size="md"
+              placeholder="영문+숫자, 8~16자리 이상"
+              :error="true"
+              errorMessage="에러메시지"
+            />
+            <BaseProgressBar :strength-score="0" variant="password-strength" :show-label="true" />
+          </FormField>
+          <div
+            class="mt-size-12 border-primary-primary800 bg-primary-primary100 p-size-8 text-font-12 text-default-muted-dark rounded-md border"
+          >
+            <p>8자 이상 입력해주세요</p>
+            <p>영문 대/소문자, 숫자, 특수문자를 포함해주세요</p>
+            <p>연속된 문자나 반복 문자는 피해주세요</p>
+          </div>
+          <FormField label="비밀번호 확인">
+            <BaseInput
+              v-model="state.passwordCheck"
+              size="md"
+              placeholder="다시 입력해주세요"
+              :error="true"
+              errorMessage="비밀번호가 일치하지 않아요"
+            />
+          </FormField>
+        </div>
+        <div class="gap-size-12 mt-[33px] flex items-center">
+          <BaseButton size="regular" label="다음" variant="primary" @click="step = 5" />
+        </div>
+      </div>
+    </template>
+  </AuthContent>
+</template>
+
+<script lang="ts" setup>
+import { BaseIcon, BasePaginationJoin, BaseInput, BaseButton, BaseProgressBar } from '@template/ui';
+import FormField from '@/components/auth/common/FormField.vue';
+import AuthContent from '@/components/auth/AuthContent.vue';
+import { reactive } from 'vue';
+
+const step = defineModel<number>('step', { required: true });
+
+const state = reactive({
+  password: '',
+  passwordCheck: '',
+});
+</script>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualSetPassword.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualSetPassword.vue
@@ -37,7 +37,14 @@
           </FormField>
         </div>
         <div class="gap-size-12 mt-[33px] flex items-center">
-          <BaseButton size="regular" label="다음" variant="primary" @click="step = 5" />
+          <BaseButton
+            size="large"
+            label="다음"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 5"
+          />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualSingUpComplete.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualSingUpComplete.vue
@@ -3,11 +3,11 @@
     <template #content>
       <div class="flex flex-col items-center justify-center">
         <div>
-          <span class="text-font-24 font-semibold">비밀번호 재설정 완료</span>
+          <span class="text-font-24 font-semibold">가입신청 완료</span>
         </div>
         <div class="mt-size-24 text-font-16 text-center">
-          <p>비밀번호 재설징이 완료 됐어요</p>
-          <p>다시 로그인해주세요</p>
+          <p>가입신청이 완료되었습니다.</p>
+          <p>관리자 확인 후 이메일로 승인 알림을 보내드릴게요!</p>
         </div>
       </div>
       <div><BaseButton label="확인" /></div>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualSingUpComplete.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualSingUpComplete.vue
@@ -10,7 +10,7 @@
           <p>관리자 확인 후 이메일로 승인 알림을 보내드릴게요!</p>
         </div>
       </div>
-      <div><BaseButton label="확인" /></div>
+      <div><BaseButton label="확인" full-width /></div>
     </template>
   </AuthContent>
 </template>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualTerms.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualTerms.vue
@@ -1,19 +1,73 @@
 <template>
   <AuthContent title="개인회원 가입" description="가입 약관을 확인해주세요.">
     <template #header>
-      <div class="mb-12">탑 버튼 영역</div>
+      <div class="flex items-center justify-between">
+        <BaseIcon name="arrow-backward" size="md" />
+        <BasePaginationJoin :count="3" :current="0" />
+      </div>
     </template>
     <template #content>
-      <div class="mt-12">
+      <div>
         <div class="border-b-2 border-black pb-[10px]">
-          <h2>가입 약관 동의</h2>
+          <h2 class="text-font-14 font-semibold">가입 약관 동의</h2>
         </div>
-        <div class="mt-6">체크박스 영역</div>
+        <div class="mt-6">
+          <div class="p-size-12 border-bg-outline rounded-[10px] border">
+            <CheckBoxLabel v-model:isChecked="isChecked">
+              <span class="text-font-15 font-semibold">모든 약관에 동의합니다.</span>
+            </CheckBoxLabel>
+          </div>
+          <div class="gap-size-8 px-size-12 mt-size-8 flex flex-col">
+            <CheckBoxLabel v-model:isChecked="isChecked">
+              <div class="text-font-12 flex w-full items-center justify-between">
+                <div class="font-medium">
+                  서비스 이용 약관 동의
+                  <span class="text-red">(필수)</span>
+                </div>
+                <div class="gap-size-2 flex items-center">
+                  상세보기
+                  <BaseIcon name="arrow-right-thin" size="sm" />
+                </div>
+              </div>
+            </CheckBoxLabel>
+            <CheckBoxLabel v-model:isChecked="isChecked">
+              <div class="text-font-12 flex w-full items-center justify-between">
+                <div class="font-medium">
+                  개인정보 수집 및 이용 동의
+                  <span class="text-red">(필수)</span>
+                </div>
+                <div class="gap-size-2 flex items-center">
+                  상세보기
+                  <BaseIcon name="arrow-right-thin" size="sm" />
+                </div>
+              </div>
+            </CheckBoxLabel>
+            <CheckBoxLabel v-model:isChecked="isChecked">
+              <div class="text-font-12 flex w-full items-center justify-between">
+                <div class="font-medium">
+                  마케팅 활용 및 광고성 정보 수신 동의
+                  <span class="text-default-muted">(선택)</span>
+                </div>
+                <div class="gap-size-2 flex items-center">
+                  상세보기
+                  <BaseIcon name="arrow-right-thin" size="sm" />
+                </div>
+              </div>
+            </CheckBoxLabel>
+          </div>
+        </div>
+        <div class="mt-[33px] w-[360px]">
+          <BaseButton size="regular" label="가입하기" variant="primary" />
+        </div>
       </div>
-      <div class="mt-[33px] w-[360px]">버튼 영역 다음</div>
     </template>
   </AuthContent>
 </template>
 <script lang="ts" setup>
+import { BaseIcon, BasePaginationJoin, BaseButton } from '@template/ui';
+import CheckBoxLabel from '@/components/auth/common/CheckBoxLabel.vue';
 import AuthContent from '@/components/auth/AuthContent.vue';
+import { ref } from 'vue';
+
+const isChecked = ref(false);
 </script>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualTerms.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualTerms.vue
@@ -57,7 +57,14 @@
           </div>
         </div>
         <div class="mt-[33px]">
-          <BaseButton size="regular" label="가입하기" variant="primary" @click="step = 1" />
+          <BaseButton
+            size="large"
+            label="가입하기"
+            variant="contained"
+            color="primary"
+            full-width
+            @click="step = 1"
+          />
         </div>
       </div>
     </template>

--- a/apps/sample-desktop/src/components/auth/signup/individual/IndividualTerms.vue
+++ b/apps/sample-desktop/src/components/auth/signup/individual/IndividualTerms.vue
@@ -3,7 +3,7 @@
     <template #header>
       <div class="flex items-center justify-between">
         <BaseIcon name="arrow-backward" size="md" />
-        <BasePaginationJoin :count="3" :current="0" />
+        <BasePaginationJoin :count="4" :current="0" />
       </div>
     </template>
     <template #content>
@@ -56,8 +56,8 @@
             </CheckBoxLabel>
           </div>
         </div>
-        <div class="mt-[33px] w-[360px]">
-          <BaseButton size="regular" label="가입하기" variant="primary" />
+        <div class="mt-[33px]">
+          <BaseButton size="regular" label="가입하기" variant="primary" @click="step = 1" />
         </div>
       </div>
     </template>
@@ -70,4 +70,6 @@ import AuthContent from '@/components/auth/AuthContent.vue';
 import { ref } from 'vue';
 
 const isChecked = ref(false);
+
+const step = defineModel<number>('step', { required: true });
 </script>

--- a/apps/sample-desktop/src/components/layout/MainLayout.vue
+++ b/apps/sample-desktop/src/components/layout/MainLayout.vue
@@ -1,9 +1,8 @@
 <template>
   <Header />
-  <main class="">
+  <main>
     <slot />
   </main>
-
   <Footer />
 </template>
 <script lang="ts" setup>

--- a/apps/sample-desktop/src/components/layout/fragments/NoneLayout.vue
+++ b/apps/sample-desktop/src/components/layout/fragments/NoneLayout.vue
@@ -1,3 +1,4 @@
 <template>
-  <main class="bg-bg-surface min-w-[1920px] flex-1"><slot /></main>
+  <main class="flex h-screen items-center justify-center p-8"><slot /></main>
 </template>
+<script lang="ts" setup></script>

--- a/apps/sample-desktop/src/router/index.ts
+++ b/apps/sample-desktop/src/router/index.ts
@@ -31,6 +31,11 @@ const routes: RouteRecordRaw[] = [
             name: 'individual-sign-up',
             component: () => import('@/views/auth/signup/individual/Index.vue'),
           },
+          {
+            path: 'corporate',
+            name: 'corporate-sign-up',
+            component: () => import('@/views/auth/signup/corporate/Index.vue'),
+          },
         ],
       },
       {

--- a/apps/sample-desktop/src/router/index.ts
+++ b/apps/sample-desktop/src/router/index.ts
@@ -84,7 +84,7 @@ const routes: RouteRecordRaw[] = [
     path: '/my-page',
     name: 'MyPage',
     meta: { layout: MainLayout },
-    component: () => import('@/views/mypage/Index.vue'),
+    component: () => import('@/views/myPage/Index.vue'),
   },
 ];
 

--- a/apps/sample-desktop/src/views/auth/findId/Index.vue
+++ b/apps/sample-desktop/src/views/auth/findId/Index.vue
@@ -1,17 +1,10 @@
 <template>
-  <div class="flex min-h-screen items-center justify-center">
-    <MainCardContent>
-      <template #content>
-        <AuthFindId v-if="step === 0" v-model:step="step" />
-        <AuthFindIdResult v-if="step === 1" />
-      </template>
-    </MainCardContent>
-  </div>
+  <AuthFindId v-if="step === 0" v-model:step="step" />
+  <AuthFindIdResult v-if="step === 1" />
 </template>
 
 <script lang="ts" setup>
 import AuthFindIdResult from '@/components/auth/findId/AuthFindIdResult.vue';
-import MainCardContent from '@/components/common/cards/MainCardContent.vue';
 import AuthFindId from '@/components/auth/findId/AuthFindId.vue';
 import { ref } from 'vue';
 

--- a/apps/sample-desktop/src/views/auth/login/Index.vue
+++ b/apps/sample-desktop/src/views/auth/login/Index.vue
@@ -1,10 +1,13 @@
 <template>
   <div class="flex min-h-screen items-center justify-center">
     <MainCardContent>
-      <template #content> </template>
+      <template #content>
+        <BaseLogin />
+      </template>
     </MainCardContent>
   </div>
 </template>
 <script lang="ts" setup>
 import MainCardContent from '@/components/common/cards/MainCardContent.vue';
+import BaseLogin from '@/components/auth/login/BaseLogin.vue';
 </script>

--- a/apps/sample-desktop/src/views/auth/login/Index.vue
+++ b/apps/sample-desktop/src/views/auth/login/Index.vue
@@ -1,13 +1,6 @@
 <template>
-  <div class="flex min-h-screen items-center justify-center">
-    <MainCardContent>
-      <template #content>
-        <BaseLogin />
-      </template>
-    </MainCardContent>
-  </div>
+  <BaseLogin />
 </template>
 <script lang="ts" setup>
-import MainCardContent from '@/components/common/cards/MainCardContent.vue';
 import BaseLogin from '@/components/auth/login/BaseLogin.vue';
 </script>

--- a/apps/sample-desktop/src/views/auth/resetPassword/Index.vue
+++ b/apps/sample-desktop/src/views/auth/resetPassword/Index.vue
@@ -1,14 +1,8 @@
 <template>
-  <div class="flex min-h-screen items-center justify-center">
-    <MainCardContent>
-      <template #content>
-        <ResetPasswordEmailForm v-if="step === 0" v-model:step="step" />
-        <ResetPasswordEmailAuth v-if="step === 1" v-model:step="step" />
-        <ResetPasswordNewPassword v-if="step === 2" v-model:step="step" />
-        <ResetPasswordComplete v-if="step === 3" />
-      </template>
-    </MainCardContent>
-  </div>
+  <ResetPasswordEmailForm v-if="step === 0" v-model:step="step" />
+  <ResetPasswordEmailAuth v-if="step === 1" v-model:step="step" />
+  <ResetPasswordNewPassword v-if="step === 2" v-model:step="step" />
+  <ResetPasswordComplete v-if="step === 3" />
 </template>
 
 <script lang="ts" setup>
@@ -16,7 +10,6 @@ import ResetPasswordNewPassword from '@/components/auth/resetPassword/ResetPassw
 import ResetPasswordEmailForm from '@/components/auth/resetPassword/ResetPasswordEmailForm.vue';
 import ResetPasswordEmailAuth from '@/components/auth/resetPassword/ResetPasswordEmailAuth.vue';
 import ResetPasswordComplete from '@/components/auth/resetPassword/ResetPasswordComplete.vue';
-import MainCardContent from '@/components/common/cards/MainCardContent.vue';
 import { ref } from 'vue';
 
 const step = ref(0);

--- a/apps/sample-desktop/src/views/auth/signup/Index.vue
+++ b/apps/sample-desktop/src/views/auth/signup/Index.vue
@@ -1,13 +1,6 @@
 <template>
-  <div class="flex min-h-screen items-center justify-center">
-    <MainCardContent>
-      <template #content>
-        <SignUpIntro />
-      </template>
-    </MainCardContent>
-  </div>
+  <SignUpIntro />
 </template>
 <script lang="ts" setup>
-import MainCardContent from '@/components/common/cards/MainCardContent.vue';
 import SignUpIntro from '@/components/auth/signup/SignUpIntro.vue';
 </script>

--- a/apps/sample-desktop/src/views/auth/signup/corporate/Index.vue
+++ b/apps/sample-desktop/src/views/auth/signup/corporate/Index.vue
@@ -1,13 +1,10 @@
 <template>
   <div class="flex min-h-screen items-center justify-center">
     <MainCardContent>
-      <template #content>
-        <SignUpIntro />
-      </template>
+      <template #content> 법인 회원가입 화면면 </template>
     </MainCardContent>
   </div>
 </template>
 <script lang="ts" setup>
 import MainCardContent from '@/components/common/cards/MainCardContent.vue';
-import SignUpIntro from '@/components/auth/signup/SignUpIntro.vue';
 </script>

--- a/apps/sample-desktop/src/views/auth/signup/corporate/Index.vue
+++ b/apps/sample-desktop/src/views/auth/signup/corporate/Index.vue
@@ -1,10 +1,2 @@
-<template>
-  <div class="flex min-h-screen items-center justify-center">
-    <MainCardContent>
-      <template #content> 법인 회원가입 화면면 </template>
-    </MainCardContent>
-  </div>
-</template>
-<script lang="ts" setup>
-import MainCardContent from '@/components/common/cards/MainCardContent.vue';
-</script>
+<template>법인 회원가입 화면면</template>
+<script lang="ts" setup></script>

--- a/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
+++ b/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
@@ -2,9 +2,9 @@
   <div class="flex min-h-screen items-center justify-center">
     <MainCardContent>
       <template #content>
-        <IndividualTerms v-if="step === 0" />
-        <IndividualPhone v-if="step === 1" />
-        <IndividualInfo v-if="step === 2" />
+        <IndividualTerms v-if="step === 0" v-model:step="step" />
+        <IndividualPhone v-if="step === 1" v-model:step="step" />
+        <IndividualInfo v-if="step === 2" v-model:step="step" />
       </template>
     </MainCardContent>
   </div>

--- a/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
+++ b/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
@@ -1,18 +1,12 @@
 <template>
-  <div class="flex min-h-screen items-center justify-center">
-    <MainCardContent>
-      <template #content>
-        <IndividualTerms v-if="step === 0" v-model:step="step" />
-        <IndividualPhone v-if="step === 1" v-model:step="step" />
-        <IndividualEmailForm v-if="step === 2" v-model:step="step" />
-        <IndividualEmailAuth v-if="step === 3" v-model:step="step" />
-        <IndividualSetPassword v-if="step === 4" v-model:step="step" />
-        <IndividualInfo v-if="step === 5" v-model:step="step" />
-        <IndividualDocument v-if="step === 6" v-model:step="step" />
-        <IndividualSingUpComplete v-if="step === 7" v-model:step="step" />
-      </template>
-    </MainCardContent>
-  </div>
+  <IndividualTerms v-if="step === 0" v-model:step="step" />
+  <IndividualPhone v-if="step === 1" v-model:step="step" />
+  <IndividualEmailForm v-if="step === 2" v-model:step="step" />
+  <IndividualEmailAuth v-if="step === 3" v-model:step="step" />
+  <IndividualSetPassword v-if="step === 4" v-model:step="step" />
+  <IndividualInfo v-if="step === 5" v-model:step="step" />
+  <IndividualDocument v-if="step === 6" v-model:step="step" />
+  <IndividualSingUpComplete v-if="step === 7" v-model:step="step" />
 </template>
 <script lang="ts" setup>
 import IndividualSingUpComplete from '@/components/auth/signup/individual/IndividualSingUpComplete.vue';
@@ -23,7 +17,6 @@ import IndividualDocument from '@/components/auth/signup/individual/IndividualDo
 import IndividualTerms from '@/components/auth/signup/individual/IndividualTerms.vue';
 import IndividualPhone from '@/components/auth/signup/individual/IndividualPhone.vue';
 import IndividualInfo from '@/components/auth/signup/individual/IndividualInfo.vue';
-import MainCardContent from '@/components/common/cards/MainCardContent.vue';
 import { ref } from 'vue';
 
 const step = ref(0);

--- a/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
+++ b/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
@@ -8,6 +8,7 @@
         <IndividualEmailAuth v-if="step === 3" v-model:step="step" />
         <IndividualSetPassword v-if="step === 4" v-model:step="step" />
         <IndividualInfo v-if="step === 5" v-model:step="step" />
+        <IndividualDocument v-if="step === 6" v-model:step="step" />
       </template>
     </MainCardContent>
   </div>
@@ -16,6 +17,7 @@
 import IndividualSetPassword from '@/components/auth/signup/individual/IndividualSetPassword.vue';
 import IndividualEmailForm from '@/components/auth/signup/individual/IndividualEmailForm.vue';
 import IndividualEmailAuth from '@/components/auth/signup/individual/IndividualEmailAuth.vue';
+import IndividualDocument from '@/components/auth/signup/individual/IndividualDocument.vue';
 import IndividualTerms from '@/components/auth/signup/individual/IndividualTerms.vue';
 import IndividualPhone from '@/components/auth/signup/individual/IndividualPhone.vue';
 import IndividualInfo from '@/components/auth/signup/individual/IndividualInfo.vue';

--- a/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
+++ b/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
@@ -4,12 +4,18 @@
       <template #content>
         <IndividualTerms v-if="step === 0" v-model:step="step" />
         <IndividualPhone v-if="step === 1" v-model:step="step" />
-        <IndividualInfo v-if="step === 2" v-model:step="step" />
+        <IndividualEmailForm v-if="step === 2" v-model:step="step" />
+        <IndividualEmailAuth v-if="step === 3" v-model:step="step" />
+        <IndividualSetPassword v-if="step === 4" v-model:step="step" />
+        <IndividualInfo v-if="step === 5" v-model:step="step" />
       </template>
     </MainCardContent>
   </div>
 </template>
 <script lang="ts" setup>
+import IndividualSetPassword from '@/components/auth/signup/individual/IndividualSetPassword.vue';
+import IndividualEmailForm from '@/components/auth/signup/individual/IndividualEmailForm.vue';
+import IndividualEmailAuth from '@/components/auth/signup/individual/IndividualEmailAuth.vue';
 import IndividualTerms from '@/components/auth/signup/individual/IndividualTerms.vue';
 import IndividualPhone from '@/components/auth/signup/individual/IndividualPhone.vue';
 import IndividualInfo from '@/components/auth/signup/individual/IndividualInfo.vue';

--- a/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
+++ b/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
@@ -9,11 +9,13 @@
         <IndividualSetPassword v-if="step === 4" v-model:step="step" />
         <IndividualInfo v-if="step === 5" v-model:step="step" />
         <IndividualDocument v-if="step === 6" v-model:step="step" />
+        <IndividualSingUpComplete v-if="step === 7" v-model:step="step" />
       </template>
     </MainCardContent>
   </div>
 </template>
 <script lang="ts" setup>
+import IndividualSingUpComplete from '@/components/auth/signup/individual/IndividualSingUpComplete.vue';
 import IndividualSetPassword from '@/components/auth/signup/individual/IndividualSetPassword.vue';
 import IndividualEmailForm from '@/components/auth/signup/individual/IndividualEmailForm.vue';
 import IndividualEmailAuth from '@/components/auth/signup/individual/IndividualEmailAuth.vue';

--- a/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
+++ b/apps/sample-desktop/src/views/auth/signup/individual/Index.vue
@@ -1,20 +1,20 @@
 <template>
-  <div class="flex items-center justify-center min-h-screen">
+  <div class="flex min-h-screen items-center justify-center">
     <MainCardContent>
       <template #content>
-        <IndividualTerms v-if="step === 1" />
-        <IndividualPhone v-if="step === 2" />
-        <IndividualInfo v-if="step === 3" />
+        <IndividualTerms v-if="step === 0" />
+        <IndividualPhone v-if="step === 1" />
+        <IndividualInfo v-if="step === 2" />
       </template>
     </MainCardContent>
   </div>
 </template>
 <script lang="ts" setup>
-import MainCardContent from '@/components/common/cards/MainCardContent.vue';
 import IndividualTerms from '@/components/auth/signup/individual/IndividualTerms.vue';
 import IndividualPhone from '@/components/auth/signup/individual/IndividualPhone.vue';
 import IndividualInfo from '@/components/auth/signup/individual/IndividualInfo.vue';
+import MainCardContent from '@/components/common/cards/MainCardContent.vue';
 import { ref } from 'vue';
 
-const step = ref(3);
+const step = ref(0);
 </script>

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -7,6 +7,7 @@ export { default as BaseProgressBar } from './BaseProgressBar/BaseProgressBar.vu
 export { default as BasePasswordStrength } from './BasePasswordStrength/BasePasswordStrength.vue';
 export { default as BaseChip } from './BaseChips/BaseChip.vue';
 export { default as BaseCheckbox } from './BaseCheckbox/BaseCheckbox.vue';
+export { default as BaseFileUploadButton } from './BaseButton/BaseFileUploadButton.vue';
 
 // TODO: BaseChip 컴포넌트 재설계 이후 제거 예정
 // export { default as ChipPosition } from './BaseChips/ChipPosition.vue';


### PR DESCRIPTION
## 📋 개요
개인회원가입 화면의 퍼블리싱과 Auth 레이아웃 반응성 개선을 진행했습니다.

## ✨ 주요 변경사항
개인회원가입 플로우 완성: 약관동의 → 휴대폰 인증 → 비밀번호/정보 입력 → 서류제출 → 완료화면
로그인 화면 퍼블리싱: 새로운 로그인 UI 구현
레이아웃 개선: NoneLayout 영역 수정
UI 컴포넌트 개선: 버튼 full-width 적용

## 📄화면
<img width="180"  alt="image" src="https://github.com/user-attachments/assets/b4c1ff7f-9650-4244-bb84-36ae9cb75cf6" />
<img width="180" alt="image" src="https://github.com/user-attachments/assets/38a1ea16-0c0d-4a88-8b08-808443ca2d6f" />
<img width="180" alt="image" src="https://github.com/user-attachments/assets/2dfdc0e6-30f9-4af5-9313-21d066d9516c" />
<img width="180" alt="image" src="https://github.com/user-attachments/assets/f39145e0-96d1-417c-9d1f-322370dc9099" />
<img width="180" alt="image" src="https://github.com/user-attachments/assets/00812285-0fb8-478c-b2e6-d440a957fba3" /><img width="180"" alt="image" src="https://github.com/user-attachments/assets/633b5bdf-bb88-4d8c-8068-d3d2744cc793" />
<img width="180" alt="image" src="https://github.com/user-attachments/assets/abcb3be2-65b8-466a-96e6-d63ed5133ea0" />
<img width="180" alt="image" src="https://github.com/user-attachments/assets/3415add5-244c-45fc-903c-dee4847b80ce" />


