### PR TITLE
feat(packages/ui): RadioGroup 컴포넌트 구현

### DIFF
--- a/packages/ui/src/components/BaseRadioGroup/BaseRadioGroup.vue
+++ b/packages/ui/src/components/BaseRadioGroup/BaseRadioGroup.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { RadioGroup, RadioGroupLabel, RadioGroupOption } from '@headlessui/vue';
+import { ref, watch } from 'vue';
+import type { RadioOption } from '../../types/components';
+import BaseIcon from '../BaseIcon/BaseIcon.vue';
+
+interface Props {
+  /**
+   * 라디오 옵션 목록
+   */
+  options: RadioOption[];
+  /**
+   * 현재 선택된 값
+   */
+  modelValue?: any;
+  /**
+   * 초기 선택값 (modelValue가 없을 때만 사용)
+   */
+  initialValue?: any;
+  /**
+   * 라디오 그룹 라벨
+   */
+  label?: string;
+  /**
+   * 비활성화 여부
+   */
+  disabled?: boolean;
+  /**
+   * 폼에서 사용할 name 속성
+   */
+  name?: string;
+  /**
+   * 객체 비교를 위한 키 또는 비교 함수
+   */
+  by?: string | ((a: any, b: any) => boolean);
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  options: () => [],
+  label: '',
+  disabled: false,
+  name: '',
+});
+
+const emit = defineEmits<{
+  'update:modelValue': [value: any];
+}>();
+
+// 내부 선택 상태 관리
+const internalValue = ref(props.modelValue ?? props.initialValue);
+
+// modelValue가 변경되면 내부 상태도 업데이트
+watch(() => props.modelValue, (newValue) => {
+  if (newValue !== undefined) {
+    internalValue.value = newValue;
+  }
+});
+
+// 내부 상태가 변경되면 부모에게 알림
+watch(internalValue, (newValue) => {
+  emit('update:modelValue', newValue);
+});
+
+/**
+ * 라디오 옵션의 클래스를 동적으로 생성하는 함수
+ * @param checked - 선택된 옵션 여부
+ * @param active - 활성 상태 여부
+ * @param disabled - 비활성화 여부
+ * @returns CSS 클래스 문자열
+ */
+const getRadioOptionClasses = (
+  checked: boolean,
+  active: boolean = false,
+  disabled: boolean = false
+): string => {
+  const baseClasses = 'focus:outline-none focus:ring-0 flex items-center gap-x-2 px-3 py-1.5 text-[13px] leading-[16px] tracking-tight rounded-xs font-medium transition-colors duration-200';
+
+  // 비활성화 상태
+  if (disabled) {
+    return [
+      baseClasses,
+      'opacity-50 cursor-not-allowed text-[var(--button-tab-text-off)]'
+    ].join(' ');
+  }
+
+  // 선택된 상태
+  if (checked) {
+    return [
+      baseClasses,
+      'bg-[var(--button-tab-button-on)] text-[var(--button-tab-text-on)]'
+    ].join(' ');
+  }
+
+  // 활성 상태 (호버/포커스)
+  if (active) {
+    return [
+      baseClasses,
+      'bg-[var(--button-tab-button-hover)] text-[var(--button-tab-text-on)]'
+    ].join(' ');
+  }
+
+  // 기본 상태
+  return [
+    baseClasses,
+    'text-[var(--button-tab-text-off)] hover:bg-[var(--button-tab-button-hover)] hover:text-[var(--button-tab-text-on)]'
+  ].join(' ');
+};
+</script>
+
+<template>
+  <div class="w-full">
+    <!-- 라디오 그룹 컨테이너 -->
+    <RadioGroup
+      v-model="internalValue"
+      :disabled="disabled"
+      :name="name"
+      :by="by"
+      class="space-y-2"
+    >
+      <!-- 라디오 그룹 라벨 -->
+      <RadioGroupLabel
+        v-if="label"
+        class="block text-sm font-medium text-gray-700"
+      >
+        {{ label }}
+      </RadioGroupLabel>
+
+      <!-- 라디오 옵션들 -->
+      <div class="flex p-1 bg-neutral-neutral050 rounded-[6px] gap-x-[10px]">
+        <RadioGroupOption
+          v-for="option in options"
+          :key="option.value"
+          :value="option.value"
+          :disabled="option.disabled || disabled"
+          as="template"
+          v-slot="{ checked, active, disabled: optionDisabled }"
+        >
+          <button
+            :class="getRadioOptionClasses(checked, active, optionDisabled)"
+            :disabled="optionDisabled"
+            type="button"
+          >
+            <!-- 아이콘이 있는 경우 -->
+            <BaseIcon
+              v-if="option.icon"
+              :name="option.icon"
+              class="w-4 h-4"
+            />
+
+            <!-- 옵션 라벨 -->
+            {{ option.label }}
+          </button>
+        </RadioGroupOption>
+      </div>
+    </RadioGroup>
+  </div>
+</template> 

--- a/packages/ui/src/components/BaseRadioGroup/BaseRadioGroup.vue
+++ b/packages/ui/src/components/BaseRadioGroup/BaseRadioGroup.vue
@@ -2,21 +2,12 @@
 import { RadioGroup, RadioGroupLabel, RadioGroupOption } from '@headlessui/vue';
 import type { RadioOption } from '../../types/components';
 import BaseIcon from '../BaseIcon/BaseIcon.vue';
-import { ref, watch } from 'vue';
 
 interface Props {
   /**
    * 라디오 옵션 목록
    */
   options: RadioOption[];
-  /**
-   * 현재 선택된 값
-   */
-  modelValue?: any;
-  /**
-   * 초기 선택값 (modelValue가 없을 때만 사용)
-   */
-  initialValue?: any;
   /**
    * 라디오 그룹 라벨
    */
@@ -35,34 +26,14 @@ interface Props {
   by?: string | ((a: any, b: any) => boolean);
 }
 
-const props = withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<Props>(), {
   options: () => [],
   label: '',
   disabled: false,
   name: '',
 });
 
-const emit = defineEmits<{
-  'update:modelValue': [value: any];
-}>();
-
-// 내부 선택 상태 관리
-const internalValue = ref(props.modelValue ?? props.initialValue);
-
-// modelValue가 변경되면 내부 상태도 업데이트
-watch(
-  () => props.modelValue,
-  (newValue) => {
-    if (newValue !== undefined) {
-      internalValue.value = newValue;
-    }
-  }
-);
-
-// 내부 상태가 변경되면 부모에게 알림
-watch(internalValue, (newValue) => {
-  emit('update:modelValue', newValue);
-});
+const model = defineModel<any>();
 
 /**
  * 라디오 옵션의 클래스를 동적으로 생성하는 함수
@@ -112,13 +83,7 @@ const getRadioOptionClasses = (
 <template>
   <div class="w-full">
     <!-- 라디오 그룹 컨테이너 -->
-    <RadioGroup
-      v-model="internalValue"
-      :disabled="disabled"
-      :name="name"
-      :by="by"
-      class="space-y-2"
-    >
+    <RadioGroup v-model="model" :disabled="disabled" :name="name" :by="by" class="space-y-2">
       <!-- 라디오 그룹 라벨 -->
       <RadioGroupLabel v-if="label" class="block text-sm font-medium text-gray-700">
         {{ label }}

--- a/packages/ui/src/components/BaseRadioGroup/BaseRadioGroup.vue
+++ b/packages/ui/src/components/BaseRadioGroup/BaseRadioGroup.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { RadioGroup, RadioGroupLabel, RadioGroupOption } from '@headlessui/vue';
-import { ref, watch } from 'vue';
 import type { RadioOption } from '../../types/components';
 import BaseIcon from '../BaseIcon/BaseIcon.vue';
+import { ref, watch } from 'vue';
 
 interface Props {
   /**
@@ -50,11 +50,14 @@ const emit = defineEmits<{
 const internalValue = ref(props.modelValue ?? props.initialValue);
 
 // modelValue가 변경되면 내부 상태도 업데이트
-watch(() => props.modelValue, (newValue) => {
-  if (newValue !== undefined) {
-    internalValue.value = newValue;
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    if (newValue !== undefined) {
+      internalValue.value = newValue;
+    }
   }
-});
+);
 
 // 내부 상태가 변경되면 부모에게 알림
 watch(internalValue, (newValue) => {
@@ -73,36 +76,35 @@ const getRadioOptionClasses = (
   active: boolean = false,
   disabled: boolean = false
 ): string => {
-  const baseClasses = 'focus:outline-none focus:ring-0 flex items-center gap-x-2 px-3 py-1.5 text-[13px] leading-[16px] tracking-tight rounded-xs font-medium transition-colors duration-200';
+  const baseClasses =
+    'focus:outline-none focus:ring-0 flex items-center gap-x-2 px-3 py-1.5 text-[13px] leading-[16px] tracking-tight rounded-xs font-medium transition-colors duration-200';
 
   // 비활성화 상태
   if (disabled) {
-    return [
-      baseClasses,
-      'opacity-50 cursor-not-allowed text-[var(--button-tab-text-off)]'
-    ].join(' ');
+    return [baseClasses, 'opacity-50 cursor-not-allowed text-[var(--button-tab-text-off)]'].join(
+      ' '
+    );
   }
 
   // 선택된 상태
   if (checked) {
-    return [
-      baseClasses,
-      'bg-[var(--button-tab-button-on)] text-[var(--button-tab-text-on)]'
-    ].join(' ');
+    return [baseClasses, 'bg-[var(--button-tab-button-on)] text-[var(--button-tab-text-on)]'].join(
+      ' '
+    );
   }
 
   // 활성 상태 (호버/포커스)
   if (active) {
     return [
       baseClasses,
-      'bg-[var(--button-tab-button-hover)] text-[var(--button-tab-text-on)]'
+      'bg-[var(--button-tab-button-hover)] text-[var(--button-tab-text-on)]',
     ].join(' ');
   }
 
   // 기본 상태
   return [
     baseClasses,
-    'text-[var(--button-tab-text-off)] hover:bg-[var(--button-tab-button-hover)] hover:text-[var(--button-tab-text-on)]'
+    'text-[var(--button-tab-text-off)] hover:bg-[var(--button-tab-button-hover)] hover:text-[var(--button-tab-text-on)]',
   ].join(' ');
 };
 </script>
@@ -118,15 +120,12 @@ const getRadioOptionClasses = (
       class="space-y-2"
     >
       <!-- 라디오 그룹 라벨 -->
-      <RadioGroupLabel
-        v-if="label"
-        class="block text-sm font-medium text-gray-700"
-      >
+      <RadioGroupLabel v-if="label" class="block text-sm font-medium text-gray-700">
         {{ label }}
       </RadioGroupLabel>
 
       <!-- 라디오 옵션들 -->
-      <div class="flex p-1 bg-neutral-neutral050 rounded-[6px] gap-x-[10px]">
+      <div class="bg-neutral-neutral050 flex gap-x-[10px] rounded-[6px] p-1">
         <RadioGroupOption
           v-for="option in options"
           :key="option.value"
@@ -141,11 +140,7 @@ const getRadioOptionClasses = (
             type="button"
           >
             <!-- 아이콘이 있는 경우 -->
-            <BaseIcon
-              v-if="option.icon"
-              :name="option.icon"
-              class="w-4 h-4"
-            />
+            <BaseIcon v-if="option.icon" :name="option.icon" class="h-4 w-4" />
 
             <!-- 옵션 라벨 -->
             {{ option.label }}
@@ -154,4 +149,4 @@ const getRadioOptionClasses = (
       </div>
     </RadioGroup>
   </div>
-</template> 
+</template>

--- a/packages/ui/src/components/BaseRadioGroup/README.md
+++ b/packages/ui/src/components/BaseRadioGroup/README.md
@@ -1,0 +1,206 @@
+# BaseRadioGroup
+
+라디오 버튼 그룹을 제공하는 Vue 3 컴포넌트입니다. Headless UI를 기반으로 하여 접근성과 사용성을 보장합니다.
+
+> 📚 **참고 문서**: [Headless UI Radio Group 공식 문서](https://headlessui.com/v1/vue/radio-group)
+
+## 기본 사용법
+
+### 단순한 문자열 옵션
+
+```vue
+<template>
+  <BaseRadioGroup
+    v-model="selectedOption"
+    :options="options"
+    label="옵션 선택"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import BaseRadioGroup from '@/components/BaseRadioGroup/BaseRadioGroup.vue'
+import type { RadioOption } from '@/types/components'
+
+const options: RadioOption[] = [
+  { value: 'option1', label: '옵션 1' },
+  { value: 'option2', label: '옵션 2' },
+  { value: 'option3', label: '옵션 3' }
+]
+
+const selectedOption = ref('option1')
+</script>
+```
+
+### 객체 옵션 (by 속성 사용)
+
+```vue
+<template>
+  <BaseRadioGroup
+    v-model="selectedUser"
+    :options="userOptions"
+    label="사용자 선택"
+    by="id"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import BaseRadioGroup from '@/components/BaseRadioGroup/BaseRadioGroup.vue'
+import type { RadioOption } from '@/types/components'
+
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+const userOptions: RadioOption<User>[] = [
+  {
+    value: { id: 'user-1', name: '김철수', email: 'kim@example.com' },
+    label: '김철수',
+    icon: 'user'
+  },
+  {
+    value: { id: 'user-2', name: '이영희', email: 'lee@example.com' },
+    label: '이영희',
+    icon: 'user'
+  }
+]
+
+const selectedUser = ref<User | null>(null)
+</script>
+```
+
+## Props
+
+| Prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `options` | `RadioOption[]` | `[]` | 라디오 옵션 목록 |
+| `modelValue` | `any` | `undefined` | 현재 선택된 값 (v-model) |
+| `initialValue` | `any` | `undefined` | 초기 선택값 (modelValue가 없을 때만 사용) |
+| `label` | `string` | `''` | 라디오 그룹 라벨 |
+| `disabled` | `boolean` | `false` | 전체 그룹 비활성화 여부 |
+| `name` | `string` | `''` | 폼에서 사용할 name 속성 |
+| `by` | `string \| ((a: any, b: any) => boolean)` | `undefined` | 객체 비교를 위한 키 또는 비교 함수 |
+
+## Events
+
+| Event | Payload | 설명 |
+|-------|---------|------|
+| `update:modelValue` | `value: any` | 선택된 값이 변경될 때 발생 |
+
+## RadioOption 타입
+
+```typescript
+interface RadioOption<T = any> {
+  value: T;           // 옵션의 값
+  label: string;      // 옵션에 표시될 텍스트
+  icon?: IconName;    // 아이콘 (선택사항)
+  disabled?: boolean; // 비활성화 여부 (선택사항)
+}
+```
+
+## by 속성의 중요성
+
+### 객체 옵션 사용 시 필수
+
+JavaScript에서 객체는 참조로 비교되기 때문에, 객체 옵션을 사용할 때는 `by` 속성이 필수입니다.
+
+```typescript
+// ❌ by 속성 없이 사용하면 올바르게 작동하지 않음
+const option1 = { id: 'user-1', name: '김철수' }
+const option2 = { id: 'user-1', name: '김철수' }
+
+option1 === option2  // false (참조가 다름)
+
+// ✅ by="id"를 사용하면 올바르게 작동
+// Headless UI가 option1.id === option2.id로 비교
+```
+
+### by 속성 사용 방법
+
+#### 문자열 키 사용 (권장)
+```vue
+<BaseRadioGroup
+  v-model="selectedUser"
+  :options="userOptions"
+  by="id"  <!-- user.id를 기준으로 비교 -->
+/>
+```
+
+#### 커스텀 함수 사용
+```vue
+<BaseRadioGroup
+  v-model="selectedUser"
+  :options="userOptions"
+  :by="(a, b) => a.id === b.id"  <!-- 커스텀 비교 로직 -->
+/>
+```
+
+## 스타일링
+
+컴포넌트는 Tailwind CSS와 CSS 변수를 사용하여 스타일링됩니다. 주요 스타일 클래스:
+
+- **기본 상태**: `text-[var(--button-tab-text-off)]`
+- **선택된 상태**: `bg-[var(--button-tab-button-on)] text-[var(--button-tab-text-on)]`
+- **호버 상태**: `hover:bg-[var(--button-tab-button-hover)] hover:text-[var(--button-tab-text-on)]`
+- **비활성화 상태**: `opacity-50 cursor-not-allowed`
+
+## 접근성
+
+- Headless UI 기반으로 ARIA 속성 자동 적용
+- 키보드 네비게이션 지원
+- 스크린 리더 호환성 보장
+
+## 예제
+
+### 사용자 역할 선택
+```vue
+<template>
+  <BaseRadioGroup
+    v-model="selectedRole"
+    :options="roleOptions"
+    label="사용자 역할"
+    by="id"
+  />
+</template>
+
+<script setup lang="ts">
+const roleOptions: RadioOption[] = [
+  { value: { id: 'admin', name: '관리자' }, label: '관리자', icon: 'shield' },
+  { value: { id: 'user', name: '일반 사용자' }, label: '일반 사용자', icon: 'user' },
+  { value: { id: 'guest', name: '게스트' }, label: '게스트', icon: 'guest' }
+]
+
+const selectedRole = ref(null)
+</script>
+```
+
+### 테마 선택
+```vue
+<template>
+  <BaseRadioGroup
+    v-model="selectedTheme"
+    :options="themeOptions"
+    label="테마 선택"
+  />
+</template>
+
+<script setup lang="ts">
+const themeOptions: RadioOption[] = [
+  { value: 'light', label: '라이트', icon: 'sun' },
+  { value: 'dark', label: '다크', icon: 'moon' },
+  { value: 'auto', label: '자동', icon: 'auto' }
+]
+
+const selectedTheme = ref('light')
+</script>
+```
+
+## 주의사항
+
+1. **객체 옵션 사용 시**: 반드시 `by` 속성을 설정하세요
+2. **타입 안전성**: TypeScript를 사용하여 옵션 타입을 명시하세요
+3. **접근성**: 라벨을 제공하여 스크린 리더 사용자를 지원하세요
+4. **성능**: 많은 옵션이 있는 경우 가상화를 고려하세요

--- a/packages/ui/src/components/BaseRadioGroup/index.ts
+++ b/packages/ui/src/components/BaseRadioGroup/index.ts
@@ -1,2 +1,2 @@
 export { default as BaseRadioGroup } from './BaseRadioGroup.vue';
-export type { RadioOption } from '../../types/components'; 
+export type { RadioOption } from '../../types/components';

--- a/packages/ui/src/components/BaseRadioGroup/index.ts
+++ b/packages/ui/src/components/BaseRadioGroup/index.ts
@@ -1,0 +1,2 @@
+export { default as BaseRadioGroup } from './BaseRadioGroup.vue';
+export type { RadioOption } from '../../types/components'; 

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -9,6 +9,7 @@ export { default as BaseChip } from './BaseChips/BaseChip.vue';
 export { default as BaseCheckbox } from './BaseCheckbox/BaseCheckbox.vue';
 export { default as BaseFileUploadButton } from './BaseButton/BaseFileUploadButton.vue';
 export { default as BaseStepper } from './BaseStepper/BaseStepper.vue';
+export { default as BaseRadioGroup } from './BaseRadioGroup/BaseRadioGroup.vue';
 
 export * from './BasePagination';
 export * from './BaseTable';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -17,6 +17,7 @@ export * from './BaseIcon';
 export * from './BaseModal';
 export * from './BaseSkeleton';
 export * from './BaseStepper';
+export * from './BaseRadioGroup';
 
 // 타입 export
 export * from '../types/components';

--- a/packages/ui/src/stories/BaseRadioGroup.stories.ts
+++ b/packages/ui/src/stories/BaseRadioGroup.stories.ts
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from '@storybook/vue3';
 import BaseRadioGroup from '../components/BaseRadioGroup/BaseRadioGroup.vue';
+import type { Meta, StoryObj } from '@storybook/vue3';
 import { ref, computed } from 'vue';
 
 const meta: Meta<typeof BaseRadioGroup> = {
@@ -9,7 +9,8 @@ const meta: Meta<typeof BaseRadioGroup> = {
     layout: 'centered',
     docs: {
       description: {
-        component: 'Headless UI를 기반으로 한 라디오 그룹 컴포넌트입니다. BaseTabs의 inner variant와 동일한 스타일을 적용하여 일관된 디자인을 제공합니다. initialValue로 초기 선택값을 설정할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+        component:
+          'Headless UI를 기반으로 한 라디오 그룹 컴포넌트입니다. BaseTabs의 inner variant와 동일한 스타일을 적용하여 일관된 디자인을 제공합니다. initialValue로 초기 선택값을 설정할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -59,7 +60,8 @@ export const Default: Story = {
   parameters: {
     docs: {
       description: {
-        story: '기본적인 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택됩니다. 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+        story:
+          '기본적인 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택됩니다. 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -79,7 +81,8 @@ export const WithIcons: Story = {
   parameters: {
     docs: {
       description: {
-        story: '각 옵션에 아이콘이 포함된 라디오 그룹입니다. initialValue를 "startup"으로 설정하여 "스타트업" 옵션이 초기 선택됩니다. 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+        story:
+          '각 옵션에 아이콘이 포함된 라디오 그룹입니다. initialValue를 "startup"으로 설정하여 "스타트업" 옵션이 초기 선택됩니다. 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -99,7 +102,8 @@ export const WithDisabledOptions: Story = {
   parameters: {
     docs: {
       description: {
-        story: '일부 옵션이 비활성화된 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택됩니다. 비활성화된 옵션은 선택할 수 없지만, 활성화된 옵션들은 자유롭게 변경할 수 있습니다.',
+        story:
+          '일부 옵션이 비활성화된 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택됩니다. 비활성화된 옵션은 선택할 수 없지만, 활성화된 옵션들은 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -120,7 +124,8 @@ export const Disabled: Story = {
   parameters: {
     docs: {
       description: {
-        story: '전체가 비활성화된 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택되지만, disabled prop으로 인해 모든 옵션을 선택할 수 없습니다.',
+        story:
+          '전체가 비활성화된 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택되지만, disabled prop으로 인해 모든 옵션을 선택할 수 없습니다.',
       },
     },
   },
@@ -141,7 +146,8 @@ export const WithForm: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'HTML 폼에서 사용할 수 있는 라디오 그룹입니다. initialValue를 "male"로 설정하여 "남성" 옵션이 초기 선택됩니다. name 속성을 통해 폼 제출 시 값이 전송되며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+        story:
+          'HTML 폼에서 사용할 수 있는 라디오 그룹입니다. initialValue를 "male"로 설정하여 "남성" 옵션이 초기 선택됩니다. name 속성을 통해 폼 제출 시 값이 전송되며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -163,7 +169,8 @@ export const WithNumericValues: Story = {
   parameters: {
     docs: {
       description: {
-        story: '숫자 값을 사용하는 라디오 그룹입니다. initialValue를 1로 설정하여 "1개" 옵션이 초기 선택됩니다. 문자열뿐만 아니라 숫자 값도 사용할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+        story:
+          '숫자 값을 사용하는 라디오 그룹입니다. initialValue를 1로 설정하여 "1개" 옵션이 초기 선택됩니다. 문자열뿐만 아니라 숫자 값도 사용할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -184,7 +191,8 @@ export const WithObjectValues: Story = {
   parameters: {
     docs: {
       description: {
-        story: '객체 값을 사용하는 라디오 그룹입니다. initialValue를 startup 객체로 설정하여 "스타트업" 옵션이 초기 선택됩니다. by prop을 사용하여 객체 비교 방법을 지정할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+        story:
+          '객체 값을 사용하는 라디오 그룹입니다. initialValue를 startup 객체로 설정하여 "스타트업" 옵션이 초기 선택됩니다. by prop을 사용하여 객체 비교 방법을 지정할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -203,7 +211,8 @@ export const WithoutInitialValue: Story = {
   parameters: {
     docs: {
       description: {
-        story: '초기값이 설정되지 않은 라디오 그룹입니다. initialValue를 설정하지 않으면 아무 옵션도 선택되지 않은 상태로 시작됩니다. 사용자가 옵션을 클릭해야 선택되며, 선택 후에는 다른 옵션으로 자유롭게 변경할 수 있습니다.',
+        story:
+          '초기값이 설정되지 않은 라디오 그룹입니다. initialValue를 설정하지 않으면 아무 옵션도 선택되지 않은 상태로 시작됩니다. 사용자가 옵션을 클릭해야 선택되며, 선택 후에는 다른 옵션으로 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -216,9 +225,21 @@ export const EventFilter: Story = {
     setup() {
       // 이벤트 목록 데이터
       const events = ref([
-        { id: 1, title: 'Vue.js 컨퍼런스 2024', status: 'ongoing', date: '2024-12-15', attendees: 150 },
+        {
+          id: 1,
+          title: 'Vue.js 컨퍼런스 2024',
+          status: 'ongoing',
+          date: '2024-12-15',
+          attendees: 150,
+        },
         { id: 2, title: 'React 워크샵', status: 'ongoing', date: '2024-12-20', attendees: 80 },
-        { id: 3, title: 'TypeScript 마스터클래스', status: 'ended', date: '2024-11-30', attendees: 120 },
+        {
+          id: 3,
+          title: 'TypeScript 마스터클래스',
+          status: 'ended',
+          date: '2024-11-30',
+          attendees: 120,
+        },
         { id: 4, title: 'Node.js 해커톤', status: 'ended', date: '2024-11-15', attendees: 200 },
         { id: 5, title: 'AI 개발자 밋업', status: 'upcoming', date: '2025-01-10', attendees: 60 },
         { id: 6, title: 'DevOps 컨퍼런스', status: 'upcoming', date: '2025-01-25', attendees: 100 },
@@ -240,7 +261,7 @@ export const EventFilter: Story = {
         if (selectedFilter.value === 'all') {
           return events.value;
         }
-        return events.value.filter(event => event.status === selectedFilter.value);
+        return events.value.filter((event) => event.status === selectedFilter.value);
       });
 
       // 이벤트 상태에 따른 배지 스타일
@@ -351,8 +372,9 @@ export const EventFilter: Story = {
   parameters: {
     docs: {
       description: {
-        story: '이벤트 필터링을 위한 라디오 그룹 예시입니다. "전체", "진행 중", "종료", "예정" 중 선택하여 이벤트 목록을 필터링할 수 있습니다. 선택된 필터에 따라 실시간으로 이벤트 목록이 업데이트되며, 각 이벤트의 상태, 날짜, 참가자 수를 확인할 수 있습니다.',
+        story:
+          '이벤트 필터링을 위한 라디오 그룹 예시입니다. "전체", "진행 중", "종료", "예정" 중 선택하여 이벤트 목록을 필터링할 수 있습니다. 선택된 필터에 따라 실시간으로 이벤트 목록이 업데이트되며, 각 이벤트의 상태, 날짜, 참가자 수를 확인할 수 있습니다.',
       },
     },
   },
-}; 
+};

--- a/packages/ui/src/stories/BaseRadioGroup.stories.ts
+++ b/packages/ui/src/stories/BaseRadioGroup.stories.ts
@@ -227,7 +227,7 @@ export const WithNumericValues: Story = {
   },
 };
 
-// 객체 값을 사용하는 라디오 그룹
+// 객체 값을 사용하는 라디오 그룹 (by="id")
 export const WithObjectValues: Story = {
   render: () => ({
     components: { BaseRadioGroup },
@@ -243,7 +243,7 @@ export const WithObjectValues: Story = {
           { value: { id: 'business', name: '비즈니스', price: 20000 }, label: '비즈니스' },
           { value: { id: 'enterprise', name: '엔터프라이즈', price: 50000 }, label: '엔터프라이즈' },
         ]"
-        label="플랜 선택 (객체)"
+        label="플랜 선택 (by='id')"
         by="id"
       />
     `,
@@ -253,6 +253,75 @@ export const WithObjectValues: Story = {
       description: {
         story:
           '객체 값을 사용하는 라디오 그룹입니다. v-model="selectedPlan"으로 선택값을 관리하며, ref(startup 객체)로 초기값을 설정하여 "스타트업" 옵션이 초기 선택됩니다. by prop을 사용하여 객체 비교 방법을 지정할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+};
+
+// by에 조건식을 사용하는 라디오 그룹
+export const WithCustomComparison: Story = {
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      const selectedUser = ref({
+        id: 'user1',
+        name: '김철수',
+        role: 'admin',
+        department: 'IT',
+      });
+
+      // 복잡한 비교 조건: role과 department가 모두 일치해야 함
+      const compareUsers = (a: any, b: any) => {
+        return a.role === b.role && a.department === b.department;
+      };
+
+      return { selectedUser, compareUsers };
+    },
+    template: `
+      <div class="space-y-4">
+        <BaseRadioGroup
+          v-model="selectedUser"
+          :options="[
+            { 
+              value: { id: 'user1', name: '김철수', role: 'admin', department: 'IT' }, 
+              label: '김철수 (IT/관리자)' 
+            },
+            { 
+              value: { id: 'user2', name: '이영희', role: 'admin', department: 'IT' }, 
+              label: '이영희 (IT/관리자)' 
+            },
+            { 
+              value: { id: 'user3', name: '박민수', role: 'user', department: 'IT' }, 
+              label: '박민수 (IT/사용자)' 
+            },
+            { 
+              value: { id: 'user4', name: '최지영', role: 'admin', department: 'HR' }, 
+              label: '최지영 (HR/관리자)' 
+            },
+          ]"
+          label="사용자 선택 (role + department 비교)"
+          :by="compareUsers"
+        />
+        
+        <div class="text-sm text-gray-600 space-y-2">
+          <p><strong>선택된 사용자:</strong> {{ selectedUser.name }}</p>
+          <p><strong>역할:</strong> {{ selectedUser.role === 'admin' ? '관리자' : '사용자' }}</p>
+          <p><strong>부서:</strong> {{ selectedUser.department }}</p>
+        </div>
+        
+        <div class="text-xs text-gray-500 bg-gray-50 p-3 rounded">
+          <p><strong>비교 로직:</strong></p>
+          <p>role과 department가 모두 일치하는 사용자만 같은 그룹으로 인식됩니다.</p>
+          <p>예: IT 관리자끼리는 서로 선택 가능, IT 사용자는 별도 그룹</p>
+        </div>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'by prop에 커스텀 비교 함수를 사용하는 예시입니다. role과 department가 모두 일치하는 사용자만 같은 그룹으로 인식되어 선택 가능합니다. 복잡한 객체 비교 로직을 구현할 수 있습니다.',
       },
     },
   },

--- a/packages/ui/src/stories/BaseRadioGroup.stories.ts
+++ b/packages/ui/src/stories/BaseRadioGroup.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta<typeof BaseRadioGroup> = {
     docs: {
       description: {
         component:
-          'Headless UI를 기반으로 한 라디오 그룹 컴포넌트입니다. BaseTabs의 inner variant와 동일한 스타일을 적용하여 일관된 디자인을 제공합니다. initialValue로 초기 선택값을 설정할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+          'Headless UI를 기반으로 한 라디오 그룹 컴포넌트입니다. BaseTabs의 inner variant와 동일한 스타일을 적용하여 일관된 디자인을 제공합니다. v-model을 통해 선택값을 관리하며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -20,10 +20,7 @@ const meta: Meta<typeof BaseRadioGroup> = {
       control: 'object',
       description: '라디오 옵션 목록',
     },
-    initialValue: {
-      control: 'text',
-      description: '초기 선택값 (modelValue가 없을 때만 사용)',
-    },
+
     label: {
       control: 'text',
       description: '라디오 그룹 라벨',
@@ -48,20 +45,29 @@ type Story = StoryObj<typeof meta>;
 
 // 기본 라디오 그룹
 export const Default: Story = {
-  args: {
-    options: [
-      { value: 'option1', label: '옵션 1' },
-      { value: 'option2', label: '옵션 2' },
-      { value: 'option3', label: '옵션 3' },
-    ],
-    initialValue: 'option1',
-    label: '선택하세요',
-  },
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      const selectedValue = ref('option1');
+      return { selectedValue };
+    },
+    template: `
+      <BaseRadioGroup
+        v-model="selectedValue"
+        :options="[
+          { value: 'option1', label: '옵션 1' },
+          { value: 'option2', label: '옵션 2' },
+          { value: 'option3', label: '옵션 3' },
+        ]"
+        label="선택하세요"
+      />
+    `,
+  }),
   parameters: {
     docs: {
       description: {
         story:
-          '기본적인 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택됩니다. 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+          '기본적인 라디오 그룹입니다. v-model="selectedValue"로 선택값을 관리하며, ref("option1")로 초기값을 설정하여 첫 번째 옵션이 초기 선택됩니다. 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -69,20 +75,29 @@ export const Default: Story = {
 
 // 아이콘이 있는 라디오 그룹
 export const WithIcons: Story = {
-  args: {
-    options: [
-      { value: 'startup', label: '스타트업', icon: 'plus' },
-      { value: 'business', label: '비즈니스', icon: 'home' },
-      { value: 'enterprise', label: '엔터프라이즈', icon: 'star' },
-    ],
-    initialValue: 'startup',
-    label: '플랜 선택',
-  },
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      const selectedPlan = ref('startup');
+      return { selectedPlan };
+    },
+    template: `
+      <BaseRadioGroup
+        v-model="selectedPlan"
+        :options="[
+          { value: 'startup', label: '스타트업', icon: 'plus' },
+          { value: 'business', label: '비즈니스', icon: 'home' },
+          { value: 'enterprise', label: '엔터프라이즈', icon: 'star' },
+        ]"
+        label="플랜 선택"
+      />
+    `,
+  }),
   parameters: {
     docs: {
       description: {
         story:
-          '각 옵션에 아이콘이 포함된 라디오 그룹입니다. initialValue를 "startup"으로 설정하여 "스타트업" 옵션이 초기 선택됩니다. 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+          '각 옵션에 아이콘이 포함된 라디오 그룹입니다. v-model="selectedPlan"으로 선택값을 관리하며, ref("startup")로 초기값을 설정하여 "스타트업" 옵션이 초기 선택됩니다. 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -90,20 +105,29 @@ export const WithIcons: Story = {
 
 // 비활성화된 옵션이 있는 라디오 그룹
 export const WithDisabledOptions: Story = {
-  args: {
-    options: [
-      { value: 'option1', label: '옵션 1' },
-      { value: 'option2', label: '옵션 2', disabled: true },
-      { value: 'option3', label: '옵션 3' },
-    ],
-    initialValue: 'option1',
-    label: '옵션 선택',
-  },
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      const selectedOption = ref('option1');
+      return { selectedOption };
+    },
+    template: `
+      <BaseRadioGroup
+        v-model="selectedOption"
+        :options="[
+          { value: 'option1', label: '옵션 1' },
+          { value: 'option2', label: '옵션 2', disabled: true },
+          { value: 'option3', label: '옵션 3' },
+        ]"
+        label="옵션 선택"
+      />
+    `,
+  }),
   parameters: {
     docs: {
       description: {
         story:
-          '일부 옵션이 비활성화된 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택됩니다. 비활성화된 옵션은 선택할 수 없지만, 활성화된 옵션들은 자유롭게 변경할 수 있습니다.',
+          '일부 옵션이 비활성화된 라디오 그룹입니다. v-model="selectedOption"으로 선택값을 관리하며, ref("option1")로 초기값을 설정하여 첫 번째 옵션이 초기 선택됩니다. 비활성화된 옵션은 선택할 수 없지만, 활성화된 옵션들은 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -111,21 +135,30 @@ export const WithDisabledOptions: Story = {
 
 // 전체 비활성화된 라디오 그룹
 export const Disabled: Story = {
-  args: {
-    options: [
-      { value: 'option1', label: '옵션 1' },
-      { value: 'option2', label: '옵션 2' },
-      { value: 'option3', label: '옵션 3' },
-    ],
-    initialValue: 'option1',
-    label: '비활성화된 그룹',
-    disabled: true,
-  },
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      const selectedOption = ref('option1');
+      return { selectedOption };
+    },
+    template: `
+      <BaseRadioGroup
+        v-model="selectedOption"
+        :options="[
+          { value: 'option1', label: '옵션 1' },
+          { value: 'option2', label: '옵션 2' },
+          { value: 'option3', label: '옵션 3' },
+        ]"
+        label="비활성화된 그룹"
+        :disabled="true"
+      />
+    `,
+  }),
   parameters: {
     docs: {
       description: {
         story:
-          '전체가 비활성화된 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택되지만, disabled prop으로 인해 모든 옵션을 선택할 수 없습니다.',
+          '전체가 비활성화된 라디오 그룹입니다. v-model="selectedOption"으로 선택값을 관리하며, ref("option1")로 초기값을 설정하여 첫 번째 옵션이 초기 선택되지만, disabled prop으로 인해 모든 옵션을 선택할 수 없습니다.',
       },
     },
   },
@@ -133,21 +166,30 @@ export const Disabled: Story = {
 
 // 폼에서 사용하는 라디오 그룹
 export const WithForm: Story = {
-  args: {
-    options: [
-      { value: 'male', label: '남성' },
-      { value: 'female', label: '여성' },
-      { value: 'other', label: '기타' },
-    ],
-    initialValue: 'male',
-    label: '성별',
-    name: 'gender',
-  },
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      const selectedGender = ref('male');
+      return { selectedGender };
+    },
+    template: `
+      <BaseRadioGroup
+        v-model="selectedGender"
+        :options="[
+          { value: 'male', label: '남성' },
+          { value: 'female', label: '여성' },
+          { value: 'other', label: '기타' },
+        ]"
+        label="성별"
+        name="gender"
+      />
+    `,
+  }),
   parameters: {
     docs: {
       description: {
         story:
-          'HTML 폼에서 사용할 수 있는 라디오 그룹입니다. initialValue를 "male"로 설정하여 "남성" 옵션이 초기 선택됩니다. name 속성을 통해 폼 제출 시 값이 전송되며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+          'HTML 폼에서 사용할 수 있는 라디오 그룹입니다. v-model="selectedGender"로 선택값을 관리하며, ref("male")로 초기값을 설정하여 "남성" 옵션이 초기 선택됩니다. name 속성을 통해 폼 제출 시 값이 전송되며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -155,22 +197,31 @@ export const WithForm: Story = {
 
 // 숫자 값을 사용하는 라디오 그룹
 export const WithNumericValues: Story = {
-  args: {
-    options: [
-      { value: 1, label: '1개' },
-      { value: 2, label: '2개' },
-      { value: 3, label: '3개' },
-      { value: 4, label: '4개' },
-      { value: 5, label: '5개' },
-    ],
-    initialValue: 1,
-    label: '수량 선택',
-  },
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      const selectedQuantity = ref(1);
+      return { selectedQuantity };
+    },
+    template: `
+      <BaseRadioGroup
+        v-model="selectedQuantity"
+        :options="[
+          { value: 1, label: '1개' },
+          { value: 2, label: '2개' },
+          { value: 3, label: '3개' },
+          { value: 4, label: '4개' },
+          { value: 5, label: '5개' },
+        ]"
+        label="수량 선택"
+      />
+    `,
+  }),
   parameters: {
     docs: {
       description: {
         story:
-          '숫자 값을 사용하는 라디오 그룹입니다. initialValue를 1로 설정하여 "1개" 옵션이 초기 선택됩니다. 문자열뿐만 아니라 숫자 값도 사용할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+          '숫자 값을 사용하는 라디오 그룹입니다. v-model="selectedQuantity"로 선택값을 관리하며, ref(1)로 초기값을 설정하여 "1개" 옵션이 초기 선택됩니다. 문자열뿐만 아니라 숫자 값도 사용할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
@@ -178,41 +229,101 @@ export const WithNumericValues: Story = {
 
 // 객체 값을 사용하는 라디오 그룹
 export const WithObjectValues: Story = {
-  args: {
-    options: [
-      { value: { id: 'startup', name: '스타트업', price: 10000 }, label: '스타트업' },
-      { value: { id: 'business', name: '비즈니스', price: 20000 }, label: '비즈니스' },
-      { value: { id: 'enterprise', name: '엔터프라이즈', price: 50000 }, label: '엔터프라이즈' },
-    ],
-    initialValue: { id: 'startup', name: '스타트업', price: 10000 },
-    label: '플랜 선택 (객체)',
-    by: 'id',
-  },
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      const selectedPlan = ref({ id: 'startup', name: '스타트업', price: 10000 });
+      return { selectedPlan };
+    },
+    template: `
+      <BaseRadioGroup
+        v-model="selectedPlan"
+        :options="[
+          { value: { id: 'startup', name: '스타트업', price: 10000 }, label: '스타트업' },
+          { value: { id: 'business', name: '비즈니스', price: 20000 }, label: '비즈니스' },
+          { value: { id: 'enterprise', name: '엔터프라이즈', price: 50000 }, label: '엔터프라이즈' },
+        ]"
+        label="플랜 선택 (객체)"
+        by="id"
+      />
+    `,
+  }),
   parameters: {
     docs: {
       description: {
         story:
-          '객체 값을 사용하는 라디오 그룹입니다. initialValue를 startup 객체로 설정하여 "스타트업" 옵션이 초기 선택됩니다. by prop을 사용하여 객체 비교 방법을 지정할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+          '객체 값을 사용하는 라디오 그룹입니다. v-model="selectedPlan"으로 선택값을 관리하며, ref(startup 객체)로 초기값을 설정하여 "스타트업" 옵션이 초기 선택됩니다. by prop을 사용하여 객체 비교 방법을 지정할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
       },
     },
   },
 };
 
-// 초기값이 없는 라디오 그룹
+// 기본값이 없는 라디오 그룹 (v-model 없이)
 export const WithoutInitialValue: Story = {
-  args: {
-    options: [
-      { value: 'option1', label: '옵션 1' },
-      { value: 'option2', label: '옵션 2' },
-      { value: 'option3', label: '옵션 3' },
-    ],
-    label: '초기값 없음',
-  },
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      const selectedValue = ref(undefined);
+      return { selectedValue };
+    },
+    template: `
+      <BaseRadioGroup
+        v-model="selectedValue"
+        :options="[
+          { value: 'option1', label: '옵션 1' },
+          { value: 'option2', label: '옵션 2' },
+          { value: 'option3', label: '옵션 3' },
+        ]"
+        label="기본값 없음"
+      />
+      <p class="mt-4 text-sm text-gray-600">
+        선택된 값: {{ selectedValue || '없음' }}
+      </p>
+    `,
+  }),
   parameters: {
     docs: {
       description: {
         story:
-          '초기값이 설정되지 않은 라디오 그룹입니다. initialValue를 설정하지 않으면 아무 옵션도 선택되지 않은 상태로 시작됩니다. 사용자가 옵션을 클릭해야 선택되며, 선택 후에는 다른 옵션으로 자유롭게 변경할 수 있습니다.',
+          '초기값이 설정되지 않은 라디오 그룹입니다. ref(undefined)로 초기값을 설정하지 않으면 아무 옵션도 선택되지 않은 상태로 시작됩니다. 사용자가 옵션을 클릭해야 선택되며, 선택 후에는 다른 옵션으로 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+};
+
+// 초기값 설정 예시
+export const WithInitialValue: Story = {
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      const selectedValue = ref('option2'); // 초기값을 ref에 직접 설정
+      return { selectedValue };
+    },
+    template: `
+      <div class="space-y-4">
+        <BaseRadioGroup
+          v-model="selectedValue"
+          :options="[
+            { value: 'option1', label: '옵션 1' },
+            { value: 'option2', label: '옵션 2' },
+            { value: 'option3', label: '옵션 3' },
+          ]"
+          label="초기값 설정"
+        />
+        <p class="text-sm text-gray-600">
+          선택된 값: {{ selectedValue }}
+        </p>
+        <p class="text-xs text-gray-500">
+          ref('option2')로 초기값을 설정하여 "옵션 2"가 기본 선택됩니다.
+        </p>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '초기값을 설정하는 예시입니다. ref("option2")로 초기값을 설정하여 "옵션 2"가 기본 선택됩니다. defineModel을 통해 v-model이 자동으로 처리됩니다.',
       },
     },
   },

--- a/packages/ui/src/stories/BaseRadioGroup.stories.ts
+++ b/packages/ui/src/stories/BaseRadioGroup.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
 import BaseRadioGroup from '../components/BaseRadioGroup/BaseRadioGroup.vue';
-import type { RadioOption } from '../types/components';
+import { ref, computed } from 'vue';
 
 const meta: Meta<typeof BaseRadioGroup> = {
   title: 'Inputs/RadioGroup',
@@ -204,6 +204,154 @@ export const WithoutInitialValue: Story = {
     docs: {
       description: {
         story: '초기값이 설정되지 않은 라디오 그룹입니다. initialValue를 설정하지 않으면 아무 옵션도 선택되지 않은 상태로 시작됩니다. 사용자가 옵션을 클릭해야 선택되며, 선택 후에는 다른 옵션으로 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+};
+
+// 이벤트 필터링을 위한 라디오 그룹
+export const EventFilter: Story = {
+  render: () => ({
+    components: { BaseRadioGroup },
+    setup() {
+      // 이벤트 목록 데이터
+      const events = ref([
+        { id: 1, title: 'Vue.js 컨퍼런스 2024', status: 'ongoing', date: '2024-12-15', attendees: 150 },
+        { id: 2, title: 'React 워크샵', status: 'ongoing', date: '2024-12-20', attendees: 80 },
+        { id: 3, title: 'TypeScript 마스터클래스', status: 'ended', date: '2024-11-30', attendees: 120 },
+        { id: 4, title: 'Node.js 해커톤', status: 'ended', date: '2024-11-15', attendees: 200 },
+        { id: 5, title: 'AI 개발자 밋업', status: 'upcoming', date: '2025-01-10', attendees: 60 },
+        { id: 6, title: 'DevOps 컨퍼런스', status: 'upcoming', date: '2025-01-25', attendees: 100 },
+      ]);
+
+      // 필터 옵션
+      const filterOptions = ref([
+        { value: 'all', label: '전체' },
+        { value: 'ongoing', label: '진행 중' },
+        { value: 'ended', label: '종료' },
+        { value: 'upcoming', label: '예정' },
+      ]);
+
+      // 선택된 필터
+      const selectedFilter = ref('all');
+
+      // 필터링된 이벤트 목록
+      const filteredEvents = computed(() => {
+        if (selectedFilter.value === 'all') {
+          return events.value;
+        }
+        return events.value.filter(event => event.status === selectedFilter.value);
+      });
+
+      // 이벤트 상태에 따른 배지 스타일
+      const getStatusBadgeClass = (status: string) => {
+        switch (status) {
+          case 'ongoing':
+            return 'bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full';
+          case 'ended':
+            return 'bg-gray-100 text-gray-800 text-xs px-2 py-1 rounded-full';
+          case 'upcoming':
+            return 'bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full';
+          default:
+            return 'bg-gray-100 text-gray-800 text-xs px-2 py-1 rounded-full';
+        }
+      };
+
+      // 이벤트 상태에 따른 한글 라벨
+      const getStatusLabel = (status: string) => {
+        switch (status) {
+          case 'ongoing':
+            return '진행 중';
+          case 'ended':
+            return '종료';
+          case 'upcoming':
+            return '예정';
+          default:
+            return status;
+        }
+      };
+
+      return {
+        events,
+        filterOptions,
+        selectedFilter,
+        filteredEvents,
+        getStatusBadgeClass,
+        getStatusLabel,
+      };
+    },
+    template: `
+      <div class="space-y-6 max-w-4xl">
+        <!-- 필터 섹션 -->
+        <div class="bg-white p-6 rounded-lg border border-gray-200">
+          <h3 class="text-lg font-semibold text-gray-900 mb-4">이벤트 필터</h3>
+          <BaseRadioGroup
+            v-model="selectedFilter"
+            :options="filterOptions"
+            label="이벤트 상태별 필터링"
+          />
+          <p class="text-sm text-gray-600 mt-2">
+            선택된 필터: <strong>{{ selectedFilter === 'all' ? '전체' : getStatusLabel(selectedFilter) }}</strong>
+          </p>
+        </div>
+
+        <!-- 이벤트 목록 -->
+        <div class="bg-white rounded-lg border border-gray-200">
+          <div class="px-6 py-4 border-b border-gray-200">
+            <h3 class="text-lg font-semibold text-gray-900">
+              이벤트 목록 
+              <span class="text-sm font-normal text-gray-500">
+                ({{ filteredEvents.length }}개)
+              </span>
+            </h3>
+          </div>
+          
+          <div class="divide-y divide-gray-200">
+            <div
+              v-for="event in filteredEvents"
+              :key="event.id"
+              class="px-6 py-4 hover:bg-gray-50 transition-colors"
+            >
+              <div class="flex items-center justify-between">
+                <div class="flex-1">
+                  <h4 class="text-base font-medium text-gray-900">{{ event.title }}</h4>
+                  <div class="flex items-center gap-4 mt-2 text-sm text-gray-600">
+                    <span>📅 {{ event.date }}</span>
+                    <span>👥 {{ event.attendees }}명</span>
+                    <span :class="getStatusBadgeClass(event.status)">
+                      {{ getStatusLabel(event.status) }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            
+            <!-- 이벤트가 없을 때 -->
+            <div
+              v-if="filteredEvents.length === 0"
+              class="px-6 py-12 text-center text-gray-500"
+            >
+              <p>해당 조건의 이벤트가 없습니다.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- 디버그 정보 -->
+        <div class="bg-gray-50 p-4 rounded-lg">
+          <h4 class="text-sm font-medium text-gray-700 mb-2">디버그 정보</h4>
+          <div class="text-xs text-gray-600 space-y-1">
+            <p>선택된 필터: {{ selectedFilter }}</p>
+            <p>전체 이벤트 수: {{ events.length }}</p>
+            <p>필터링된 이벤트 수: {{ filteredEvents.length }}</p>
+          </div>
+        </div>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: '이벤트 필터링을 위한 라디오 그룹 예시입니다. "전체", "진행 중", "종료", "예정" 중 선택하여 이벤트 목록을 필터링할 수 있습니다. 선택된 필터에 따라 실시간으로 이벤트 목록이 업데이트되며, 각 이벤트의 상태, 날짜, 참가자 수를 확인할 수 있습니다.',
       },
     },
   },

--- a/packages/ui/src/stories/BaseRadioGroup.stories.ts
+++ b/packages/ui/src/stories/BaseRadioGroup.stories.ts
@@ -1,0 +1,210 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import BaseRadioGroup from '../components/BaseRadioGroup/BaseRadioGroup.vue';
+import type { RadioOption } from '../types/components';
+
+const meta: Meta<typeof BaseRadioGroup> = {
+  title: 'Inputs/RadioGroup',
+  component: BaseRadioGroup,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'Headless UI를 기반으로 한 라디오 그룹 컴포넌트입니다. BaseTabs의 inner variant와 동일한 스타일을 적용하여 일관된 디자인을 제공합니다. initialValue로 초기 선택값을 설정할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    options: {
+      control: 'object',
+      description: '라디오 옵션 목록',
+    },
+    initialValue: {
+      control: 'text',
+      description: '초기 선택값 (modelValue가 없을 때만 사용)',
+    },
+    label: {
+      control: 'text',
+      description: '라디오 그룹 라벨',
+    },
+    disabled: {
+      control: 'boolean',
+      description: '전체 비활성화 여부',
+    },
+    name: {
+      control: 'text',
+      description: '폼에서 사용할 name 속성',
+    },
+    by: {
+      control: 'text',
+      description: '객체 비교를 위한 키 또는 비교 함수',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 라디오 그룹
+export const Default: Story = {
+  args: {
+    options: [
+      { value: 'option1', label: '옵션 1' },
+      { value: 'option2', label: '옵션 2' },
+      { value: 'option3', label: '옵션 3' },
+    ],
+    initialValue: 'option1',
+    label: '선택하세요',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '기본적인 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택됩니다. 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+};
+
+// 아이콘이 있는 라디오 그룹
+export const WithIcons: Story = {
+  args: {
+    options: [
+      { value: 'startup', label: '스타트업', icon: 'plus' },
+      { value: 'business', label: '비즈니스', icon: 'home' },
+      { value: 'enterprise', label: '엔터프라이즈', icon: 'star' },
+    ],
+    initialValue: 'startup',
+    label: '플랜 선택',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '각 옵션에 아이콘이 포함된 라디오 그룹입니다. initialValue를 "startup"으로 설정하여 "스타트업" 옵션이 초기 선택됩니다. 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+};
+
+// 비활성화된 옵션이 있는 라디오 그룹
+export const WithDisabledOptions: Story = {
+  args: {
+    options: [
+      { value: 'option1', label: '옵션 1' },
+      { value: 'option2', label: '옵션 2', disabled: true },
+      { value: 'option3', label: '옵션 3' },
+    ],
+    initialValue: 'option1',
+    label: '옵션 선택',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '일부 옵션이 비활성화된 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택됩니다. 비활성화된 옵션은 선택할 수 없지만, 활성화된 옵션들은 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+};
+
+// 전체 비활성화된 라디오 그룹
+export const Disabled: Story = {
+  args: {
+    options: [
+      { value: 'option1', label: '옵션 1' },
+      { value: 'option2', label: '옵션 2' },
+      { value: 'option3', label: '옵션 3' },
+    ],
+    initialValue: 'option1',
+    label: '비활성화된 그룹',
+    disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '전체가 비활성화된 라디오 그룹입니다. initialValue를 "option1"로 설정하여 첫 번째 옵션이 초기 선택되지만, disabled prop으로 인해 모든 옵션을 선택할 수 없습니다.',
+      },
+    },
+  },
+};
+
+// 폼에서 사용하는 라디오 그룹
+export const WithForm: Story = {
+  args: {
+    options: [
+      { value: 'male', label: '남성' },
+      { value: 'female', label: '여성' },
+      { value: 'other', label: '기타' },
+    ],
+    initialValue: 'male',
+    label: '성별',
+    name: 'gender',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'HTML 폼에서 사용할 수 있는 라디오 그룹입니다. initialValue를 "male"로 설정하여 "남성" 옵션이 초기 선택됩니다. name 속성을 통해 폼 제출 시 값이 전송되며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+};
+
+// 숫자 값을 사용하는 라디오 그룹
+export const WithNumericValues: Story = {
+  args: {
+    options: [
+      { value: 1, label: '1개' },
+      { value: 2, label: '2개' },
+      { value: 3, label: '3개' },
+      { value: 4, label: '4개' },
+      { value: 5, label: '5개' },
+    ],
+    initialValue: 1,
+    label: '수량 선택',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '숫자 값을 사용하는 라디오 그룹입니다. initialValue를 1로 설정하여 "1개" 옵션이 초기 선택됩니다. 문자열뿐만 아니라 숫자 값도 사용할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+};
+
+// 객체 값을 사용하는 라디오 그룹
+export const WithObjectValues: Story = {
+  args: {
+    options: [
+      { value: { id: 'startup', name: '스타트업', price: 10000 }, label: '스타트업' },
+      { value: { id: 'business', name: '비즈니스', price: 20000 }, label: '비즈니스' },
+      { value: { id: 'enterprise', name: '엔터프라이즈', price: 50000 }, label: '엔터프라이즈' },
+    ],
+    initialValue: { id: 'startup', name: '스타트업', price: 10000 },
+    label: '플랜 선택 (객체)',
+    by: 'id',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '객체 값을 사용하는 라디오 그룹입니다. initialValue를 startup 객체로 설정하여 "스타트업" 옵션이 초기 선택됩니다. by prop을 사용하여 객체 비교 방법을 지정할 수 있으며, 사용자가 다른 옵션을 클릭하면 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+};
+
+// 초기값이 없는 라디오 그룹
+export const WithoutInitialValue: Story = {
+  args: {
+    options: [
+      { value: 'option1', label: '옵션 1' },
+      { value: 'option2', label: '옵션 2' },
+      { value: 'option3', label: '옵션 3' },
+    ],
+    label: '초기값 없음',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '초기값이 설정되지 않은 라디오 그룹입니다. initialValue를 설정하지 않으면 아무 옵션도 선택되지 않은 상태로 시작됩니다. 사용자가 옵션을 클릭해야 선택되며, 선택 후에는 다른 옵션으로 자유롭게 변경할 수 있습니다.',
+      },
+    },
+  },
+}; 

--- a/packages/ui/src/types/components.ts
+++ b/packages/ui/src/types/components.ts
@@ -103,6 +103,17 @@ export interface ChipData {
   icon?: string;
 }
 
+// BaseRadioGroup
+/**
+ * BaseRadioGroup 컴포넌트에서 사용하는 라디오 옵션 인터페이스
+ */
+export interface RadioOption<T = any> {
+  value: T; // 옵션의 값
+  label: string; // 옵션에 표시될 텍스트
+  icon?: IconName; // 아이콘 (선택사항)
+  disabled?: boolean; // 비활성화 여부 (선택사항)
+}
+
 // BaseModal
 export type ModalSize = 'sm' | 'md' | 'lg' | 'xl';
 export type ModalVariant = 'default' | 'confirm' | 'alert';


### PR DESCRIPTION
## ✨ 주요 기능

### BaseRadioGroup 컴포넌트
- **Headless UI 기반**: RadioGroup, RadioGroupLabel, RadioGroupOption 활용
- **BaseTabs 스타일 통일**: inner variant와 동일한 스타일 적용
- **initialValue 지원**: 초기 선택값 설정으로 초기 선택 상태 관리
- **자유로운 변경**: 사용자가 다른 옵션을 클릭하면 자유롭게 변경 가능
- **제어 가능**: v-model로도 여전히 사용 가능

### 이벤트 필터링 스토리
- **실시간 필터링**: 라디오 버튼 선택 시 즉시 이벤트 목록 업데이트
- **다양한 필터**: '전체', '진행 중', '종료', '예정' 상태별 필터링
- **상태별 배지**: 각 이벤트의 상태를 색상으로 구분하여 표시
- **반응형 데이터**: Vue 3 Composition API를 활용한 효율적인 상태 관리

## 🔧 기술적 구현

### 컴포넌트 구조
```vue
<BaseRadioGroup
  :options="filterOptions"
  :initialValue="'all'"
  label="이벤트 상태별 필터링"
/>
```

### 상태 관리
- `internalValue`: 내부 선택 상태 관리
- `watch`: modelValue와 내부 상태 동기화
- `computed`: 필터링된 이벤트 목록 실시간 계산

### 스타일링
- CSS 변수 활용으로 테마 일관성 확보
- BaseTabs의 inner variant와 동일한 디자인 시스템
- Tailwind CSS 기반 반응형 스타일링

## 🧪 테스트

### Storybook 스토리
1. **Default**: 기본 라디오 그룹
2. **WithIcons**: 아이콘이 포함된 옵션
3. **WithDisabledOptions**: 비활성화된 옵션
4. **Disabled**: 전체 비활성화
5. **WithForm**: 폼에서 사용
6. **WithNumericValues**: 숫자 값 사용
7. **WithObjectValues**: 객체 값 사용
8. **WithoutInitialValue**: 초기값 없음
9. **EventFilter**: 이벤트 필터링 (신규)

## 🎨 사용 예시

### 기본 사용법
```vue
<BaseRadioGroup
  :options="[
    { value: 'all', label: '전체' },
    { value: 'ongoing', label: '진행 중' },
    { value: 'ended', label: '종료' }
  ]"
  :initialValue="'all'"
  label="상태별 필터링"
/>
```

### 제어된 상태 사용
```vue
<BaseRadioGroup
  v-model="selectedValue"
  :options="options"
  label="선택하세요"
/>
```