### PR TITLE
주문 화면 우측 패널 퍼블리싱

### DIFF
--- a/apps/sample-desktop/src/components/order/OrderBook.vue
+++ b/apps/sample-desktop/src/components/order/OrderBook.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="flex flex-col items-center gap-1">
+    <!-- 1단계 호가 -->
+    <div class="flex h-6 w-full gap-1">
+      <div class="flex h-6 w-full items-center justify-between text-xs">
+        <div class="relative z-10">1.00</div>
+        <div class="relative">
+          <div class="relative z-10 mr-[9px]">1.16790</div>
+          <div
+            class="absolute right-0 top-1/2 h-6 w-[5px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+          ></div>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between text-xs">
+        <div class="relative">
+          <div class="relative z-10 ml-[9px]">1.00</div>
+          <div
+            class="absolute left-0 top-1/2 h-6 w-[5px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+          ></div>
+        </div>
+        <div class="relative z-10">1.16790</div>
+      </div>
+    </div>
+
+    <!-- 2단계 호가 -->
+    <div class="flex h-6 w-full gap-1">
+      <div class="flex h-6 w-full items-center justify-between text-xs">
+        <div class="relative z-10">1.00</div>
+        <div class="relative">
+          <div class="relative z-10 mr-[9px]">1.16790</div>
+          <div
+            class="absolute right-0 top-1/2 h-6 w-[40px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+          ></div>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between text-xs">
+        <div class="relative">
+          <div class="relative z-10 ml-[9px]">1.00</div>
+          <div
+            class="absolute left-0 top-1/2 h-6 w-[40px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+          ></div>
+        </div>
+        <div class="relative z-10">1.16790</div>
+      </div>
+    </div>
+
+    <!-- 3단계 호가 -->
+    <div class="flex h-6 w-full gap-1">
+      <div class="flex h-6 w-full items-center justify-between text-xs">
+        <div class="relative z-10">1.00</div>
+        <div class="relative">
+          <div class="relative z-10 mr-[9px]">1.16790</div>
+          <div
+            class="absolute right-0 top-1/2 h-6 w-[60px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+          ></div>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between text-xs">
+        <div class="relative">
+          <div class="relative z-10 ml-[9px]">1.00</div>
+          <div
+            class="absolute left-0 top-1/2 h-6 w-[60px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+          ></div>
+        </div>
+        <div class="relative z-10">1.16790</div>
+      </div>
+    </div>
+
+    <!-- 4단계 호가 -->
+    <div class="flex h-6 w-full gap-1">
+      <div class="flex h-6 w-full items-center justify-between text-xs">
+        <div class="relative z-10">1.00</div>
+        <div class="relative">
+          <div class="relative z-10 mr-[9px]">1.16790</div>
+          <div
+            class="absolute right-0 top-1/2 h-6 w-[100px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+          ></div>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between text-xs">
+        <div class="relative">
+          <div class="relative z-10 ml-[9px]">1.00</div>
+          <div
+            class="absolute left-0 top-1/2 h-6 w-[100px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+          ></div>
+        </div>
+        <div class="relative z-10">1.16790</div>
+      </div>
+    </div>
+
+    <!-- 5단계 호가 -->
+    <div class="flex h-6 w-full gap-1">
+      <div class="flex h-6 w-full items-center justify-between text-xs">
+        <div class="relative z-10">1.00</div>
+        <div class="relative">
+          <div class="relative z-10 mr-[9px]">1.16790</div>
+          <div
+            class="absolute right-0 top-1/2 h-6 w-[150px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+          ></div>
+        </div>
+      </div>
+      <div class="flex w-full items-center justify-between text-xs">
+        <div class="relative z-10">
+          <div class="relative z-10 ml-[9px]">1.00</div>
+          <div
+            class="absolute left-0 top-1/2 h-6 w-[150px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+          ></div>
+        </div>
+        <div class="relative z-10">1.16790</div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/sample-desktop/src/components/order/RightPanel.vue
+++ b/apps/sample-desktop/src/components/order/RightPanel.vue
@@ -2,6 +2,7 @@
   <div class="flex flex-col bg-white p-4">
     <!-- 계좌 선택 -->
     <div class="mt-3">
+      <!-- TODO: BaseInputSelect로 대체될 영역-->
       <div class="relative">
         <div
           @click="isDropdownOpen = !isDropdownOpen"
@@ -248,20 +249,22 @@
       >
         <!-- Stop Loss & Take Profit 체크박스 -->
         <div class="flex w-full items-center justify-between">
-          <div class="flex w-[150px] items-center gap-1">
-            <BaseCheckbox v-model="state.stopLoss" />
-            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
-              Stop Loss
-            </div>
+          <div class="w-[150px]">
+            <BaseCheckbox v-model="state.stopLoss">
+              <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+                Stop Loss
+              </div>
+            </BaseCheckbox>
           </div>
           <div
             class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
           ></div>
-          <div class="flex w-[150px] items-center gap-1">
-            <BaseCheckbox v-model="state.takeProfit" />
-            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
-              Take Profit
-            </div>
+          <div class="w-[150px]">
+            <BaseCheckbox v-model="state.takeProfit">
+              <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+                Take Profit
+              </div>
+            </BaseCheckbox>
           </div>
         </div>
 
@@ -324,10 +327,11 @@
 
         <!-- Trailing Stop 체크박스 -->
         <div class="flex w-[150px] items-center gap-1">
-          <BaseCheckbox v-model="state.trailingStop" />
-          <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
-            Trailing Stop
-          </div>
+          <BaseCheckbox v-model="state.trailingStop">
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              Trailing Stop
+            </div>
+          </BaseCheckbox>
         </div>
       </div>
     </div>

--- a/apps/sample-desktop/src/components/order/RightPanel.vue
+++ b/apps/sample-desktop/src/components/order/RightPanel.vue
@@ -1,0 +1,447 @@
+<template>
+  <div class="flex flex-col bg-white p-4">
+    <div>
+      <BaseInput />
+    </div>
+
+    <!-- 통화 페어 섹션 -->
+    <div
+      class="relative mt-3 flex items-center justify-between rounded-md border border-[#0067ef] bg-[#f5f7f9] p-4"
+    >
+      <div class="flex w-52 flex-col gap-1">
+        <div class="text-base font-semibold leading-5 tracking-[-0.35px] text-[#131313]">
+          EURUSD
+        </div>
+      </div>
+      <div class="text-base font-semibold leading-5 tracking-[-0.35px] text-[#0067ef]">1.17100</div>
+    </div>
+
+    <!-- 주문 유형 선택 -->
+    <div class="mt-2">
+      <BaseRadioGroup
+        v-model="selectedOrderType"
+        :options="orderTypeOptions"
+        label="주문 유형"
+        name="orderType"
+      />
+    </div>
+
+    <!-- 매도 매수 버튼 -->
+    <div class="mt-2 flex gap-2">
+      <BaseButton
+        variant="outlined"
+        color="red"
+        size="lg"
+        label="매도"
+        subLabel="1.17100"
+        customClass="h-16"
+        fullWidth
+      />
+      <BaseButton
+        variant="contained-grey"
+        color="blue"
+        size="lg"
+        label="매수"
+        subLabel="1.17096"
+        customClass="h-16"
+        fullWidth
+      />
+    </div>
+    <BaseProgressBar variant="performance" value="75" max="100" class="mt-2" />
+    <!-- 거래 정보 섹션 -->
+    <div
+      class="text-color-default mt-2 flex items-center justify-center gap-2 text-center text-[11px] leading-[14px] tracking-[-0.1px]"
+    >
+      <span class="whitespace-nowrap">스프레드: 0.4</span>
+      <span>|</span>
+      <span class="whitespace-nowrap">고가: 1.17496</span>
+      <span>|</span>
+      <span class="whitespace-nowrap">저가: 1.17151</span>
+    </div>
+
+    <!-- 수량 및 증거금율 섹션 -->
+    <div class="mt-6 flex w-full flex-col gap-3">
+      <!-- 수량 입력 섹션 -->
+      <div class="flex flex-col gap-1">
+        <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+          수량(Lots)
+        </div>
+        <div class="flex h-[34px] w-[168px] items-center">
+          <!-- 수량 입력 필드 -->
+          <div class="flex-1 rounded-l-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2">
+            <div class="text-[14px] font-normal leading-[18px] text-[#131313]">1.0</div>
+          </div>
+          <!-- 증가 버튼 -->
+          <div
+            class="flex items-center justify-center border border-[#b4b6bb] bg-white px-1 py-[9px]"
+          >
+            <BaseIcon name="plus" size="sm" />
+          </div>
+          <!-- 감소 버튼 -->
+          <div
+            class="flex items-center justify-center rounded-r-[6px] border border-l-0 border-[#b4b6bb] bg-white px-1 py-[9px]"
+          >
+            <BaseIcon name="minus" size="sm" />
+          </div>
+        </div>
+      </div>
+
+      <!-- 증거금율 정보 섹션 -->
+      <div class="w-full rounded-[8px] bg-[#f5f7f9] p-3">
+        <div class="flex flex-col gap-2">
+          <!-- 1 Lot 값 -->
+          <div class="flex w-full items-center justify-between text-[12px] leading-[16px]">
+            <div class="font-normal tracking-[-0.35px] text-[#717375]">1 Lot 값</div>
+            <div class="font-medium text-[#131313]">$650,840.00</div>
+          </div>
+          <!-- Pip Value -->
+          <div class="flex w-full items-center justify-between text-[12px] leading-[16px]">
+            <div class="font-normal tracking-[-0.35px] text-[#717375]">Pip Value</div>
+            <div class="font-medium text-[#131313]">$100.00</div>
+          </div>
+          <!-- 최소 증거금 -->
+          <div class="flex w-full items-center justify-between text-[12px] leading-[16px]">
+            <div class="font-normal tracking-[-0.35px] text-[#717375]">최소 증거금</div>
+            <div class="font-medium text-[#131313]">$1,301.70</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 자동 청산 섹션 -->
+    <div class="mt-6 flex w-full flex-col gap-3">
+      <!-- 자동 청산 헤더 -->
+      <div class="flex w-full flex-col gap-2">
+        <button class="flex w-full cursor-pointer items-center justify-start">
+          <div class="text-[15px] font-semibold leading-[20px] tracking-[-0.35px] text-[#131313]">
+            자동 청산
+          </div>
+          <BaseIcon name="arrow-down" size="md" />
+        </button>
+
+        <!-- 자동 청산 콘텐츠 -->
+        <div class="flex w-full flex-col gap-3">
+          <!-- Stop Loss & Take Profit 체크박스 -->
+          <div class="flex w-full items-center justify-between">
+            <div class="flex w-[150px] items-center gap-1">
+              <BaseCheckbox v-model="state.stopLoss" />
+              <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+                Stop Loss
+              </div>
+            </div>
+            <div
+              class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
+            ></div>
+            <div class="flex w-[150px] items-center gap-1">
+              <BaseCheckbox v-model="state.takeProfit" />
+              <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+                Take Profit
+              </div>
+            </div>
+          </div>
+
+          <!-- Stop Loss 입력 필드들 -->
+          <div class="flex w-full flex-col gap-1">
+            <!-- 핍 입력 -->
+            <div class="flex h-8 w-full items-center justify-between gap-1">
+              <div class="flex h-full w-[150px] items-center">
+                <div
+                  class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+                >
+                  <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
+                </div>
+                <div
+                  class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+                >
+                  <BaseIcon name="plus" size="sm" />
+                </div>
+                <div
+                  class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+                >
+                  <BaseIcon name="minus" size="sm" />
+                </div>
+              </div>
+              <div
+                class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
+              >
+                핍
+              </div>
+              <div class="flex h-full w-[150px] items-center">
+                <div
+                  class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+                >
+                  <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
+                </div>
+                <div
+                  class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+                >
+                  <BaseIcon name="plus" size="sm" />
+                </div>
+                <div
+                  class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+                >
+                  <BaseIcon name="minus" size="sm" />
+                </div>
+              </div>
+            </div>
+
+            <!-- 가격 입력 -->
+            <div class="flex h-8 w-full items-center justify-between gap-1">
+              <div class="flex h-full w-[150px] items-center">
+                <div
+                  class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+                >
+                  <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
+                </div>
+                <div
+                  class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+                >
+                  <BaseIcon name="plus" size="sm" />
+                </div>
+                <div
+                  class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+                >
+                  <BaseIcon name="minus" size="sm" />
+                </div>
+              </div>
+              <div
+                class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
+              >
+                가격
+              </div>
+              <div class="flex h-full w-[150px] items-center">
+                <div
+                  class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+                >
+                  <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
+                </div>
+                <div
+                  class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+                >
+                  <BaseIcon name="plus" size="sm" />
+                </div>
+                <div
+                  class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+                >
+                  <BaseIcon name="minus" size="sm" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Trailing Stop 체크박스 -->
+          <button class="flex w-[150px] cursor-pointer items-center gap-1">
+            <div class="flex w-[150px] items-center gap-1">
+              <BaseCheckbox v-model="state.trailingStop" />
+              <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+                Trailing Stop
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+
+      <!-- 버튼 섹션 -->
+      <div class="flex w-full flex-col gap-2.5">
+        <BaseButton label="주문 실행" />
+      </div>
+
+      <!-- 5단계 호가 섹션 -->
+      <div class="mt-6 flex w-full flex-col gap-2">
+        <div class="text-[15px] font-semibold leading-[20px] tracking-[-0.35px] text-[#131313]">
+          5단계 호가
+        </div>
+
+        <!-- 호가 차트 -->
+        <div class="flex flex-col items-center gap-1">
+          <!-- 1단계 호가 -->
+          <div class="flex h-6 w-full gap-1">
+            <div class="flex h-6 w-full items-center justify-between text-xs">
+              <div class="relative z-10">1.00</div>
+              <div class="relative">
+                <div class="relative z-10 mr-[9px]">1.16790</div>
+                <div
+                  class="absolute right-0 top-1/2 h-6 w-[5px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+                ></div>
+              </div>
+            </div>
+            <div class="flex w-full items-center justify-between text-xs">
+              <div class="relative">
+                <div class="relative z-10 ml-[9px]">1.00</div>
+                <div
+                  class="absolute left-0 top-1/2 h-6 w-[5px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+                ></div>
+              </div>
+              <div class="relative z-10">1.16790</div>
+            </div>
+          </div>
+
+          <!-- 2단계 호가 -->
+          <div class="flex h-6 w-full gap-1">
+            <div class="flex h-6 w-full items-center justify-between text-xs">
+              <div class="relative z-10">1.00</div>
+              <div class="relative">
+                <div class="relative z-10 mr-[9px]">1.16790</div>
+                <div
+                  class="absolute right-0 top-1/2 h-6 w-[40px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+                ></div>
+              </div>
+            </div>
+            <div class="flex w-full items-center justify-between text-xs">
+              <div class="relative">
+                <div class="relative z-10 ml-[9px]">1.00</div>
+                <div
+                  class="absolute left-0 top-1/2 h-6 w-[40px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+                ></div>
+              </div>
+              <div class="relative z-10">1.16790</div>
+            </div>
+          </div>
+
+          <!-- 3단계 호가 -->
+          <div class="flex h-6 w-full gap-1">
+            <div class="flex h-6 w-full items-center justify-between text-xs">
+              <div class="relative z-10">1.00</div>
+              <div class="relative">
+                <div class="relative z-10 mr-[9px]">1.16790</div>
+                <div
+                  class="absolute right-0 top-1/2 h-6 w-[60px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+                ></div>
+              </div>
+            </div>
+            <div class="flex w-full items-center justify-between text-xs">
+              <div class="relative">
+                <div class="relative z-10 ml-[9px]">1.00</div>
+                <div
+                  class="absolute left-0 top-1/2 h-6 w-[60px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+                ></div>
+              </div>
+              <div class="relative z-10">1.16790</div>
+            </div>
+          </div>
+
+          <!-- 4단계 호가 -->
+          <div class="flex h-6 w-full gap-1">
+            <div class="flex h-6 w-full items-center justify-between text-xs">
+              <div class="relative z-10">1.00</div>
+              <div class="relative">
+                <div class="relative z-10 mr-[9px]">1.16790</div>
+                <div
+                  class="absolute right-0 top-1/2 h-6 w-[100px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+                ></div>
+              </div>
+            </div>
+            <div class="flex w-full items-center justify-between text-xs">
+              <div class="relative">
+                <div class="relative z-10 ml-[9px]">1.00</div>
+                <div
+                  class="absolute left-0 top-1/2 h-6 w-[100px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+                ></div>
+              </div>
+              <div class="relative z-10">1.16790</div>
+            </div>
+          </div>
+
+          <!-- 5단계 호가 -->
+          <div class="flex h-6 w-full gap-1">
+            <div class="flex h-6 w-full items-center justify-between text-xs">
+              <div class="relative z-10">1.00</div>
+              <div class="relative">
+                <div class="relative z-10 mr-[9px]">1.16790</div>
+                <div
+                  class="absolute right-0 top-1/2 h-6 w-[150px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+                ></div>
+              </div>
+            </div>
+            <div class="flex w-full items-center justify-between text-xs">
+              <div class="relative z-10">
+                <div class="relative z-10 ml-[9px]">1.00</div>
+                <div
+                  class="absolute left-0 top-1/2 h-6 w-[150px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+                ></div>
+              </div>
+              <div class="relative z-10">1.16790</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  BaseRadioGroup,
+  BaseButton,
+  BaseIcon,
+  BaseInput,
+  BaseCheckbox,
+  BaseProgressBar,
+} from '@template/ui';
+import type { RadioOption } from '@template/ui';
+import { reactive } from 'vue';
+
+const state = reactive({
+  stopLoss: false,
+  takeProfit: false,
+  trailingStop: false,
+});
+
+/**
+ * 주문 패널의 우측 섹션 컴포넌트
+ * 통화 페어와 현재 가격을 표시하고 주문 유형을 선택할 수 있습니다.
+ */
+interface Props {
+  currencyPair?: string;
+  price?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  currencyPair: 'EURUSD',
+  price: '1.17100',
+});
+
+/**
+ * 선택된 주문 유형
+ */
+const selectedOrderType = defineModel<string>('orderType', {
+  default: 'market',
+});
+
+/**
+ * 주문 유형 옵션들
+ */
+const orderTypeOptions: RadioOption[] = [
+  {
+    value: 'market',
+    label: '시장가',
+  },
+  {
+    value: 'limit',
+    label: 'Limit',
+  },
+  {
+    value: 'stop',
+    label: 'Stop',
+  },
+  {
+    value: 'stopLimit',
+    label: 'Stop Limit',
+  },
+];
+</script>
+
+<style scoped>
+/* Pretendard GOV 폰트가 없는 경우를 대비한 fallback */
+.font-semibold {
+  font-family:
+    'Pretendard GOV',
+    'Pretendard',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+  font-weight: 600;
+}
+</style>

--- a/apps/sample-desktop/src/components/order/RightPanel.vue
+++ b/apps/sample-desktop/src/components/order/RightPanel.vue
@@ -59,7 +59,15 @@
       </button>
     </div>
 
-    <BaseProgressBar variant="performance" value="75" max="100" class="mt-2" />
+    <!-- 매수 매도 진행바 -->
+    <div class="mt-2 flex w-full flex-row items-start justify-start gap-2">
+      <div
+        class="h-1.5 w-[218px] flex-shrink-0 rounded-[999px] bg-[var(--base-colors-red-red800)]"
+      ></div>
+      <div class="h-1.5 min-w-0 flex-1">
+        <div class="bg-blue-blue800-deep h-1.5 w-full rounded-[999px]"></div>
+      </div>
+    </div>
 
     <!-- 거래 정보 섹션 -->
     <div

--- a/apps/sample-desktop/src/components/order/RightPanel.vue
+++ b/apps/sample-desktop/src/components/order/RightPanel.vue
@@ -1,12 +1,38 @@
 <template>
   <div class="flex flex-col bg-white p-4">
-    <div>
-      <BaseInput />
+    <!-- 계좌 선택 -->
+    <div class="mt-3">
+      <div class="relative">
+        <div
+          @click="toggleDropdown"
+          class="flex h-[42px] w-full cursor-pointer items-center justify-between rounded-md border border-[#b4b6bb] bg-white px-[15px] py-3 pr-3 text-[14px] font-normal leading-[18px] tracking-[-0.35px] text-[#131313]"
+        >
+          <span>{{ selectedAccountLabel }}</span>
+          <div class="pointer-events-none">
+            <BaseIcon name="arrow-down" size="md" :class="{ 'rotate-180': isDropdownOpen }" />
+          </div>
+        </div>
+
+        <div
+          v-if="isDropdownOpen"
+          class="absolute left-0 right-0 top-full z-50 mt-1 max-h-48 overflow-y-auto rounded-md border border-[#b4b6bb] bg-white shadow-lg"
+        >
+          <div
+            v-for="option in accountOptions"
+            :key="option.value"
+            @click="selectAccount(option.value)"
+            class="cursor-pointer px-[15px] py-3 text-[14px] font-normal leading-[18px] tracking-[-0.35px] text-[#131313] transition-colors duration-200 first:rounded-t-md last:rounded-b-md hover:bg-[#f8f9fa]"
+            :class="{ 'bg-[#f0f7ff] text-[#0067ef]': selectedAccount === option.value }"
+          >
+            {{ option.label }}
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- 통화 페어 섹션 -->
     <div
-      class="relative mt-3 flex items-center justify-between rounded-md border border-[#0067ef] bg-[#f5f7f9] p-4"
+      class="h-13 relative mt-3 flex items-center justify-between rounded-md border border-[#0067ef] bg-[#f5f7f9] p-4"
     >
       <div class="flex w-52 flex-col gap-1">
         <div class="text-base font-semibold leading-5 tracking-[-0.35px] text-[#131313]">
@@ -17,37 +43,24 @@
     </div>
 
     <!-- 주문 유형 선택 -->
-    <div class="mt-2">
-      <BaseRadioGroup
-        v-model="selectedOrderType"
-        :options="orderTypeOptions"
-        label="주문 유형"
-        name="orderType"
-      />
+    <div class="mt-3">
+      <BaseRadioGroup v-model="selectedOrderType" :options="orderTypeOptions" name="orderType" />
     </div>
 
     <!-- 매도 매수 버튼 -->
     <div class="mt-2 flex gap-2">
-      <BaseButton
-        variant="outlined"
-        color="red"
-        size="lg"
-        label="매도"
-        subLabel="1.17100"
-        customClass="h-16"
-        fullWidth
-      />
-      <BaseButton
-        variant="contained-grey"
-        color="blue"
-        size="lg"
-        label="매수"
-        subLabel="1.17096"
-        customClass="h-16"
-        fullWidth
-      />
+      <button :class="buyButtonClasses" @click="handleBuyClick">
+        <div class="text-font-14 font-medium leading-5 tracking-[-0.35px]">매수</div>
+        <div class="text-base font-semibold leading-5 tracking-[-0.35px]">1.17096</div>
+      </button>
+      <button :class="sellButtonClasses" @click="handleSellClick">
+        <div class="text-font-14 font-medium leading-5 tracking-[-0.35px]">매도</div>
+        <div class="text-base font-semibold leading-5 tracking-[-0.35px]">1.17096</div>
+      </button>
     </div>
+
     <BaseProgressBar variant="performance" value="75" max="100" class="mt-2" />
+
     <!-- 거래 정보 섹션 -->
     <div
       class="text-color-default mt-2 flex items-center justify-center gap-2 text-center text-[11px] leading-[14px] tracking-[-0.1px]"
@@ -91,17 +104,17 @@
         <div class="flex flex-col gap-2">
           <!-- 1 Lot 값 -->
           <div class="flex w-full items-center justify-between text-[12px] leading-[16px]">
-            <div class="font-normal tracking-[-0.35px] text-[#717375]">1 Lot 값</div>
+            <div class="text-default-muted-dark font-normal tracking-[-0.35px]">1 Lot 값</div>
             <div class="font-medium text-[#131313]">$650,840.00</div>
           </div>
           <!-- Pip Value -->
           <div class="flex w-full items-center justify-between text-[12px] leading-[16px]">
-            <div class="font-normal tracking-[-0.35px] text-[#717375]">Pip Value</div>
+            <div class="text-default-muted-dark font-normal tracking-[-0.35px]">Pip Value</div>
             <div class="font-medium text-[#131313]">$100.00</div>
           </div>
           <!-- 최소 증거금 -->
           <div class="flex w-full items-center justify-between text-[12px] leading-[16px]">
-            <div class="font-normal tracking-[-0.35px] text-[#717375]">최소 증거금</div>
+            <div class="text-default-muted-dark font-normal tracking-[-0.35px]">최소 증거금</div>
             <div class="font-medium text-[#131313]">$1,301.70</div>
           </div>
         </div>
@@ -109,259 +122,254 @@
     </div>
 
     <!-- 자동 청산 섹션 -->
-    <div class="mt-6 flex w-full flex-col gap-3">
-      <!-- 자동 청산 헤더 -->
-      <div class="flex w-full flex-col gap-2">
-        <button class="flex w-full cursor-pointer items-center justify-start">
-          <div class="text-[15px] font-semibold leading-[20px] tracking-[-0.35px] text-[#131313]">
-            자동 청산
-          </div>
-          <BaseIcon name="arrow-down" size="md" />
-        </button>
+    <div class="mt-6 flex w-full flex-col gap-2">
+      <button class="flex w-full cursor-pointer items-center justify-start">
+        <div class="text-[15px] font-semibold leading-[20px] tracking-[-0.35px] text-[#131313]">
+          자동 청산
+        </div>
+        <BaseIcon name="arrow-down" size="md" />
+      </button>
 
-        <!-- 자동 청산 콘텐츠 -->
-        <div class="flex w-full flex-col gap-3">
-          <!-- Stop Loss & Take Profit 체크박스 -->
-          <div class="flex w-full items-center justify-between">
-            <div class="flex w-[150px] items-center gap-1">
-              <BaseCheckbox v-model="state.stopLoss" />
-              <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
-                Stop Loss
-              </div>
+      <!-- 자동 청산 콘텐츠 -->
+      <!-- Stop Loss & Take Profit 체크박스 -->
+      <div class="flex w-full items-center justify-between">
+        <div class="flex w-[150px] items-center gap-1">
+          <BaseCheckbox v-model="state.stopLoss" />
+          <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+            Stop Loss
+          </div>
+        </div>
+        <div
+          class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
+        ></div>
+        <div class="flex w-[150px] items-center gap-1">
+          <BaseCheckbox v-model="state.takeProfit" />
+          <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+            Take Profit
+          </div>
+        </div>
+      </div>
+
+      <!-- Stop Loss 입력 필드들 -->
+      <div class="flex w-full flex-col gap-1">
+        <!-- 핍 입력 -->
+        <div class="flex h-8 w-full items-center justify-between gap-1">
+          <div class="flex h-full w-[150px] items-center">
+            <div
+              class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+            >
+              <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
             </div>
             <div
-              class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
-            ></div>
-            <div class="flex w-[150px] items-center gap-1">
-              <BaseCheckbox v-model="state.takeProfit" />
-              <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
-                Take Profit
-              </div>
+              class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+            >
+              <BaseIcon name="plus" size="sm" />
+            </div>
+            <div
+              class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+            >
+              <BaseIcon name="minus" size="sm" />
             </div>
           </div>
-
-          <!-- Stop Loss 입력 필드들 -->
-          <div class="flex w-full flex-col gap-1">
-            <!-- 핍 입력 -->
-            <div class="flex h-8 w-full items-center justify-between gap-1">
-              <div class="flex h-full w-[150px] items-center">
-                <div
-                  class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-                >
-                  <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
-                </div>
-                <div
-                  class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
-                >
-                  <BaseIcon name="plus" size="sm" />
-                </div>
-                <div
-                  class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-                >
-                  <BaseIcon name="minus" size="sm" />
-                </div>
-              </div>
-              <div
-                class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
-              >
-                핍
-              </div>
-              <div class="flex h-full w-[150px] items-center">
-                <div
-                  class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-                >
-                  <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
-                </div>
-                <div
-                  class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
-                >
-                  <BaseIcon name="plus" size="sm" />
-                </div>
-                <div
-                  class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-                >
-                  <BaseIcon name="minus" size="sm" />
-                </div>
-              </div>
+          <div
+            class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
+          >
+            핍
+          </div>
+          <div class="flex h-full w-[150px] items-center">
+            <div
+              class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+            >
+              <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
             </div>
-
-            <!-- 가격 입력 -->
-            <div class="flex h-8 w-full items-center justify-between gap-1">
-              <div class="flex h-full w-[150px] items-center">
-                <div
-                  class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-                >
-                  <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
-                </div>
-                <div
-                  class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
-                >
-                  <BaseIcon name="plus" size="sm" />
-                </div>
-                <div
-                  class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-                >
-                  <BaseIcon name="minus" size="sm" />
-                </div>
-              </div>
-              <div
-                class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
-              >
-                가격
-              </div>
-              <div class="flex h-full w-[150px] items-center">
-                <div
-                  class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-                >
-                  <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
-                </div>
-                <div
-                  class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
-                >
-                  <BaseIcon name="plus" size="sm" />
-                </div>
-                <div
-                  class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-                >
-                  <BaseIcon name="minus" size="sm" />
-                </div>
-              </div>
+            <div
+              class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+            >
+              <BaseIcon name="plus" size="sm" />
+            </div>
+            <div
+              class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+            >
+              <BaseIcon name="minus" size="sm" />
             </div>
           </div>
+        </div>
 
-          <!-- Trailing Stop 체크박스 -->
-          <button class="flex w-[150px] cursor-pointer items-center gap-1">
-            <div class="flex w-[150px] items-center gap-1">
-              <BaseCheckbox v-model="state.trailingStop" />
-              <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
-                Trailing Stop
-              </div>
+        <!-- 가격 입력 -->
+        <div class="flex h-8 w-full items-center justify-between gap-1">
+          <div class="flex h-full w-[150px] items-center">
+            <div
+              class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+            >
+              <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
             </div>
-          </button>
+            <div
+              class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+            >
+              <BaseIcon name="plus" size="sm" />
+            </div>
+            <div
+              class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+            >
+              <BaseIcon name="minus" size="sm" />
+            </div>
+          </div>
+          <div
+            class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
+          >
+            가격
+          </div>
+          <div class="flex h-full w-[150px] items-center">
+            <div
+              class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+            >
+              <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
+            </div>
+            <div
+              class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+            >
+              <BaseIcon name="plus" size="sm" />
+            </div>
+            <div
+              class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+            >
+              <BaseIcon name="minus" size="sm" />
+            </div>
+          </div>
         </div>
       </div>
 
-      <!-- 버튼 섹션 -->
-      <div class="flex w-full flex-col gap-2.5">
-        <BaseButton label="주문 실행" />
+      <!-- Trailing Stop 체크박스 -->
+      <button class="flex w-[150px] cursor-pointer items-center gap-1">
+        <div class="flex w-[150px] items-center gap-1">
+          <BaseCheckbox v-model="state.trailingStop" />
+          <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+            Trailing Stop
+          </div>
+        </div>
+      </button>
+    </div>
+
+    <!-- 버튼 섹션 -->
+    <div class="mt-3 flex w-full flex-col gap-2.5">
+      <BaseButton label="주문 실행" :disabled="!isBuyActive && !isSellActive" />
+    </div>
+
+    <!-- 5단계 호가 섹션 -->
+    <div class="mt-6 flex w-full flex-col gap-2">
+      <div class="text-[15px] font-semibold leading-[20px] tracking-[-0.35px] text-[#131313]">
+        5단계 호가
       </div>
 
-      <!-- 5단계 호가 섹션 -->
-      <div class="mt-6 flex w-full flex-col gap-2">
-        <div class="text-[15px] font-semibold leading-[20px] tracking-[-0.35px] text-[#131313]">
-          5단계 호가
+      <!-- 호가 차트 -->
+      <div class="flex flex-col items-center gap-1">
+        <!-- 1단계 호가 -->
+        <div class="flex h-6 w-full gap-1">
+          <div class="flex h-6 w-full items-center justify-between text-xs">
+            <div class="relative z-10">1.00</div>
+            <div class="relative">
+              <div class="relative z-10 mr-[9px]">1.16790</div>
+              <div
+                class="absolute right-0 top-1/2 h-6 w-[5px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+              ></div>
+            </div>
+          </div>
+          <div class="flex w-full items-center justify-between text-xs">
+            <div class="relative">
+              <div class="relative z-10 ml-[9px]">1.00</div>
+              <div
+                class="absolute left-0 top-1/2 h-6 w-[5px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+              ></div>
+            </div>
+            <div class="relative z-10">1.16790</div>
+          </div>
         </div>
 
-        <!-- 호가 차트 -->
-        <div class="flex flex-col items-center gap-1">
-          <!-- 1단계 호가 -->
-          <div class="flex h-6 w-full gap-1">
-            <div class="flex h-6 w-full items-center justify-between text-xs">
-              <div class="relative z-10">1.00</div>
-              <div class="relative">
-                <div class="relative z-10 mr-[9px]">1.16790</div>
-                <div
-                  class="absolute right-0 top-1/2 h-6 w-[5px] -translate-y-1/2 rounded bg-[#E0EDFF]"
-                ></div>
-              </div>
-            </div>
-            <div class="flex w-full items-center justify-between text-xs">
-              <div class="relative">
-                <div class="relative z-10 ml-[9px]">1.00</div>
-                <div
-                  class="absolute left-0 top-1/2 h-6 w-[5px] -translate-y-1/2 rounded bg-[#FFDBDC]"
-                ></div>
-              </div>
-              <div class="relative z-10">1.16790</div>
+        <!-- 2단계 호가 -->
+        <div class="flex h-6 w-full gap-1">
+          <div class="flex h-6 w-full items-center justify-between text-xs">
+            <div class="relative z-10">1.00</div>
+            <div class="relative">
+              <div class="relative z-10 mr-[9px]">1.16790</div>
+              <div
+                class="absolute right-0 top-1/2 h-6 w-[40px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+              ></div>
             </div>
           </div>
-
-          <!-- 2단계 호가 -->
-          <div class="flex h-6 w-full gap-1">
-            <div class="flex h-6 w-full items-center justify-between text-xs">
-              <div class="relative z-10">1.00</div>
-              <div class="relative">
-                <div class="relative z-10 mr-[9px]">1.16790</div>
-                <div
-                  class="absolute right-0 top-1/2 h-6 w-[40px] -translate-y-1/2 rounded bg-[#E0EDFF]"
-                ></div>
-              </div>
+          <div class="flex w-full items-center justify-between text-xs">
+            <div class="relative">
+              <div class="relative z-10 ml-[9px]">1.00</div>
+              <div
+                class="absolute left-0 top-1/2 h-6 w-[40px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+              ></div>
             </div>
-            <div class="flex w-full items-center justify-between text-xs">
-              <div class="relative">
-                <div class="relative z-10 ml-[9px]">1.00</div>
-                <div
-                  class="absolute left-0 top-1/2 h-6 w-[40px] -translate-y-1/2 rounded bg-[#FFDBDC]"
-                ></div>
-              </div>
-              <div class="relative z-10">1.16790</div>
+            <div class="relative z-10">1.16790</div>
+          </div>
+        </div>
+
+        <!-- 3단계 호가 -->
+        <div class="flex h-6 w-full gap-1">
+          <div class="flex h-6 w-full items-center justify-between text-xs">
+            <div class="relative z-10">1.00</div>
+            <div class="relative">
+              <div class="relative z-10 mr-[9px]">1.16790</div>
+              <div
+                class="absolute right-0 top-1/2 h-6 w-[60px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+              ></div>
             </div>
           </div>
-
-          <!-- 3단계 호가 -->
-          <div class="flex h-6 w-full gap-1">
-            <div class="flex h-6 w-full items-center justify-between text-xs">
-              <div class="relative z-10">1.00</div>
-              <div class="relative">
-                <div class="relative z-10 mr-[9px]">1.16790</div>
-                <div
-                  class="absolute right-0 top-1/2 h-6 w-[60px] -translate-y-1/2 rounded bg-[#E0EDFF]"
-                ></div>
-              </div>
+          <div class="flex w-full items-center justify-between text-xs">
+            <div class="relative">
+              <div class="relative z-10 ml-[9px]">1.00</div>
+              <div
+                class="absolute left-0 top-1/2 h-6 w-[60px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+              ></div>
             </div>
-            <div class="flex w-full items-center justify-between text-xs">
-              <div class="relative">
-                <div class="relative z-10 ml-[9px]">1.00</div>
-                <div
-                  class="absolute left-0 top-1/2 h-6 w-[60px] -translate-y-1/2 rounded bg-[#FFDBDC]"
-                ></div>
-              </div>
-              <div class="relative z-10">1.16790</div>
+            <div class="relative z-10">1.16790</div>
+          </div>
+        </div>
+
+        <!-- 4단계 호가 -->
+        <div class="flex h-6 w-full gap-1">
+          <div class="flex h-6 w-full items-center justify-between text-xs">
+            <div class="relative z-10">1.00</div>
+            <div class="relative">
+              <div class="relative z-10 mr-[9px]">1.16790</div>
+              <div
+                class="absolute right-0 top-1/2 h-6 w-[100px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+              ></div>
             </div>
           </div>
-
-          <!-- 4단계 호가 -->
-          <div class="flex h-6 w-full gap-1">
-            <div class="flex h-6 w-full items-center justify-between text-xs">
-              <div class="relative z-10">1.00</div>
-              <div class="relative">
-                <div class="relative z-10 mr-[9px]">1.16790</div>
-                <div
-                  class="absolute right-0 top-1/2 h-6 w-[100px] -translate-y-1/2 rounded bg-[#E0EDFF]"
-                ></div>
-              </div>
+          <div class="flex w-full items-center justify-between text-xs">
+            <div class="relative">
+              <div class="relative z-10 ml-[9px]">1.00</div>
+              <div
+                class="absolute left-0 top-1/2 h-6 w-[100px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+              ></div>
             </div>
-            <div class="flex w-full items-center justify-between text-xs">
-              <div class="relative">
-                <div class="relative z-10 ml-[9px]">1.00</div>
-                <div
-                  class="absolute left-0 top-1/2 h-6 w-[100px] -translate-y-1/2 rounded bg-[#FFDBDC]"
-                ></div>
-              </div>
-              <div class="relative z-10">1.16790</div>
+            <div class="relative z-10">1.16790</div>
+          </div>
+        </div>
+
+        <!-- 5단계 호가 -->
+        <div class="flex h-6 w-full gap-1">
+          <div class="flex h-6 w-full items-center justify-between text-xs">
+            <div class="relative z-10">1.00</div>
+            <div class="relative">
+              <div class="relative z-10 mr-[9px]">1.16790</div>
+              <div
+                class="absolute right-0 top-1/2 h-6 w-[150px] -translate-y-1/2 rounded bg-[#E0EDFF]"
+              ></div>
             </div>
           </div>
-
-          <!-- 5단계 호가 -->
-          <div class="flex h-6 w-full gap-1">
-            <div class="flex h-6 w-full items-center justify-between text-xs">
-              <div class="relative z-10">1.00</div>
-              <div class="relative">
-                <div class="relative z-10 mr-[9px]">1.16790</div>
-                <div
-                  class="absolute right-0 top-1/2 h-6 w-[150px] -translate-y-1/2 rounded bg-[#E0EDFF]"
-                ></div>
-              </div>
+          <div class="flex w-full items-center justify-between text-xs">
+            <div class="relative z-10">
+              <div class="relative z-10 ml-[9px]">1.00</div>
+              <div
+                class="absolute left-0 top-1/2 h-6 w-[150px] -translate-y-1/2 rounded bg-[#FFDBDC]"
+              ></div>
             </div>
-            <div class="flex w-full items-center justify-between text-xs">
-              <div class="relative z-10">
-                <div class="relative z-10 ml-[9px]">1.00</div>
-                <div
-                  class="absolute left-0 top-1/2 h-6 w-[150px] -translate-y-1/2 rounded bg-[#FFDBDC]"
-                ></div>
-              </div>
-              <div class="relative z-10">1.16790</div>
-            </div>
+            <div class="relative z-10">1.16790</div>
           </div>
         </div>
       </div>
@@ -378,8 +386,8 @@ import {
   BaseCheckbox,
   BaseProgressBar,
 } from '@template/ui';
+import { reactive, ref, computed, onMounted, onUnmounted } from 'vue';
 import type { RadioOption } from '@template/ui';
-import { reactive } from 'vue';
 
 const state = reactive({
   stopLoss: false,
@@ -388,18 +396,93 @@ const state = reactive({
 });
 
 /**
- * 주문 패널의 우측 섹션 컴포넌트
- * 통화 페어와 현재 가격을 표시하고 주문 유형을 선택할 수 있습니다.
+ * 선택된 계좌
  */
-interface Props {
-  currencyPair?: string;
-  price?: string;
-}
+const selectedAccount = ref('account1');
 
-const props = withDefaults(defineProps<Props>(), {
-  currencyPair: 'EURUSD',
-  price: '1.17100',
+// 드롭다운 상태 관리
+const isDropdownOpen = ref(false);
+
+// 계좌 옵션 데이터
+const accountOptions = [
+  { value: 'account1', label: '라이브계좌#1 110-81-345150' },
+  { value: 'account2', label: '라이브계좌#2 110-81-345151' },
+  { value: 'account3', label: '데모계좌#1 110-81-345152' },
+];
+
+// 선택된 계좌의 라벨
+const selectedAccountLabel = computed(() => {
+  const option = accountOptions.find((opt) => opt.value === selectedAccount.value);
+  return option?.label || '계좌를 선택하세요';
 });
+
+// 드롭다운 토글
+const toggleDropdown = () => {
+  isDropdownOpen.value = !isDropdownOpen.value;
+};
+
+// 계좌 선택
+const selectAccount = (value: string) => {
+  selectedAccount.value = value;
+  isDropdownOpen.value = false;
+};
+
+// 외부 클릭 시 드롭다운 닫기
+onMounted(() => {
+  document.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    if (!target.closest('.relative')) {
+      isDropdownOpen.value = false;
+    }
+  });
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', () => {});
+});
+
+const isBuyActive = ref(false);
+const isSellActive = ref(false);
+
+/**
+ * 매수 버튼의 동적 클래스
+ */
+const buyButtonClasses = computed(() => {
+  const baseClasses = 'flex w-full flex-col items-center justify-center gap-1 rounded-md p-3 ';
+
+  if (isBuyActive.value) {
+    return `${baseClasses} bg-[var(--base-colors-red-red050)] text-[var(--base-colors-red-red800)] outline outline-1 outline-[var(--base-colors-red-red800)] outline-offset-[-2px]`;
+  }
+
+  return `${baseClasses} bg-[var(--button-red-background-none)]  text-[var(--base-colors-red-red800)]  `;
+});
+
+/**
+ * 매도 버튼의 동적 클래스
+ */
+const sellButtonClasses = computed(() => {
+  const baseClasses = 'flex w-full flex-col items-center justify-center gap-1 rounded-md  p-3 ';
+
+  if (isSellActive.value) {
+    return `${baseClasses} bg-[var(--base-colors-blue-blue050)] text-[var(--base-colors-blue-blue800-deep)] outline outline-1 outline-[var(--base-colors-blue-blue800-deep)] outline-offset-[-2px]`;
+  }
+
+  return `${baseClasses} bg-[var(--button-red-background-none)] text-[var(--base-colors-blue-blue800-deep)]`;
+});
+
+const handleBuyClick = () => {
+  if (isSellActive.value) {
+    isSellActive.value = false;
+  }
+  isBuyActive.value = !isBuyActive.value;
+};
+
+const handleSellClick = () => {
+  if (isBuyActive.value) {
+    isBuyActive.value = false;
+  }
+  isSellActive.value = !isSellActive.value;
+};
 
 /**
  * 선택된 주문 유형
@@ -430,18 +513,3 @@ const orderTypeOptions: RadioOption[] = [
   },
 ];
 </script>
-
-<style scoped>
-/* Pretendard GOV 폰트가 없는 경우를 대비한 fallback */
-.font-semibold {
-  font-family:
-    'Pretendard GOV',
-    'Pretendard',
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    Roboto,
-    sans-serif;
-  font-weight: 600;
-}
-</style>

--- a/apps/sample-desktop/src/components/order/RightPanel.vue
+++ b/apps/sample-desktop/src/components/order/RightPanel.vue
@@ -4,7 +4,7 @@
     <div class="mt-3">
       <div class="relative">
         <div
-          @click="toggleDropdown"
+          @click="isDropdownOpen = !isDropdownOpen"
           class="flex h-[42px] w-full cursor-pointer items-center justify-between rounded-md border border-[#b4b6bb] bg-white px-[15px] py-3 pr-3 text-[14px] font-normal leading-[18px] tracking-[-0.35px] text-[#131313]"
         >
           <span>{{ selectedAccountLabel }}</span>
@@ -123,131 +123,142 @@
 
     <!-- 자동 청산 섹션 -->
     <div class="mt-6 flex w-full flex-col gap-2">
-      <button class="flex w-full cursor-pointer items-center justify-start">
+      <button
+        @click="isAutoLiquidationOpen = !isAutoLiquidationOpen"
+        class="flex w-full cursor-pointer items-center justify-start"
+      >
         <div class="text-[15px] font-semibold leading-[20px] tracking-[-0.35px] text-[#131313]">
           자동 청산
         </div>
-        <BaseIcon name="arrow-down" size="md" />
+        <BaseIcon
+          name="arrow-down"
+          size="md"
+          :class="{ 'rotate-180': isAutoLiquidationOpen }"
+          class="transition-transform duration-200"
+        />
       </button>
 
       <!-- 자동 청산 콘텐츠 -->
-      <!-- Stop Loss & Take Profit 체크박스 -->
-      <div class="flex w-full items-center justify-between">
-        <div class="flex w-[150px] items-center gap-1">
-          <BaseCheckbox v-model="state.stopLoss" />
-          <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
-            Stop Loss
-          </div>
-        </div>
-        <div
-          class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
-        ></div>
-        <div class="flex w-[150px] items-center gap-1">
-          <BaseCheckbox v-model="state.takeProfit" />
-          <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
-            Take Profit
-          </div>
-        </div>
-      </div>
-
-      <!-- Stop Loss 입력 필드들 -->
-      <div class="flex w-full flex-col gap-1">
-        <!-- 핍 입력 -->
-        <div class="flex h-8 w-full items-center justify-between gap-1">
-          <div class="flex h-full w-[150px] items-center">
-            <div
-              class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-            >
-              <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
-            </div>
-            <div
-              class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
-            >
-              <BaseIcon name="plus" size="sm" />
-            </div>
-            <div
-              class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-            >
-              <BaseIcon name="minus" size="sm" />
+      <div
+        v-if="isAutoLiquidationOpen"
+        class="flex w-full flex-col gap-2 overflow-hidden transition-all duration-200"
+      >
+        <!-- Stop Loss & Take Profit 체크박스 -->
+        <div class="flex w-full items-center justify-between">
+          <div class="flex w-[150px] items-center gap-1">
+            <BaseCheckbox v-model="state.stopLoss" />
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              Stop Loss
             </div>
           </div>
           <div
             class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
-          >
-            핍
-          </div>
-          <div class="flex h-full w-[150px] items-center">
-            <div
-              class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-            >
-              <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
-            </div>
-            <div
-              class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
-            >
-              <BaseIcon name="plus" size="sm" />
-            </div>
-            <div
-              class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-            >
-              <BaseIcon name="minus" size="sm" />
+          ></div>
+          <div class="flex w-[150px] items-center gap-1">
+            <BaseCheckbox v-model="state.takeProfit" />
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              Take Profit
             </div>
           </div>
         </div>
 
-        <!-- 가격 입력 -->
-        <div class="flex h-8 w-full items-center justify-between gap-1">
-          <div class="flex h-full w-[150px] items-center">
-            <div
-              class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-            >
-              <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
+        <!-- Stop Loss 입력 필드들 -->
+        <div class="flex w-full flex-col gap-1">
+          <!-- 핍 입력 -->
+          <div class="flex h-8 w-full items-center justify-between gap-1">
+            <div class="flex h-full w-[150px] items-center">
+              <div
+                class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+              >
+                <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
+              </div>
+              <div
+                class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+              >
+                <BaseIcon name="plus" size="sm" />
+              </div>
+              <div
+                class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+              >
+                <BaseIcon name="minus" size="sm" />
+              </div>
             </div>
             <div
-              class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+              class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
             >
-              <BaseIcon name="plus" size="sm" />
+              핍
             </div>
-            <div
-              class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-            >
-              <BaseIcon name="minus" size="sm" />
+            <div class="flex h-full w-[150px] items-center">
+              <div
+                class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+              >
+                <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
+              </div>
+              <div
+                class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+              >
+                <BaseIcon name="plus" size="sm" />
+              </div>
+              <div
+                class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+              >
+                <BaseIcon name="minus" size="sm" />
+              </div>
             </div>
           </div>
-          <div
-            class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
-          >
-            가격
-          </div>
-          <div class="flex h-full w-[150px] items-center">
-            <div
-              class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-            >
-              <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
+
+          <!-- 가격 입력 -->
+          <div class="flex h-8 w-full items-center justify-between gap-1">
+            <div class="flex h-full w-[150px] items-center">
+              <div
+                class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+              >
+                <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
+              </div>
+              <div
+                class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+              >
+                <BaseIcon name="plus" size="sm" />
+              </div>
+              <div
+                class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+              >
+                <BaseIcon name="minus" size="sm" />
+              </div>
             </div>
             <div
-              class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+              class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
             >
-              <BaseIcon name="plus" size="sm" />
+              가격
             </div>
-            <div
-              class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-            >
-              <BaseIcon name="minus" size="sm" />
+            <div class="flex h-full w-[150px] items-center">
+              <div
+                class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
+              >
+                <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
+              </div>
+              <div
+                class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
+              >
+                <BaseIcon name="plus" size="sm" />
+              </div>
+              <div
+                class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
+              >
+                <BaseIcon name="minus" size="sm" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- Trailing Stop 체크박스 -->
-      <button class="flex w-[150px] cursor-pointer items-center gap-1">
+        <!-- Trailing Stop 체크박스 -->
         <div class="flex w-[150px] items-center gap-1">
           <BaseCheckbox v-model="state.trailingStop" />
           <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
             Trailing Stop
           </div>
         </div>
-      </button>
+      </div>
     </div>
 
     <!-- 버튼 섹션 -->
@@ -378,16 +389,9 @@
 </template>
 
 <script setup lang="ts">
-import {
-  BaseRadioGroup,
-  BaseButton,
-  BaseIcon,
-  BaseInput,
-  BaseCheckbox,
-  BaseProgressBar,
-} from '@template/ui';
-import { reactive, ref, computed, onMounted, onUnmounted } from 'vue';
+import { BaseRadioGroup, BaseButton, BaseIcon, BaseCheckbox, BaseProgressBar } from '@template/ui';
 import type { RadioOption } from '@template/ui';
+import { reactive, ref, computed } from 'vue';
 
 const state = reactive({
   stopLoss: false,
@@ -395,58 +399,28 @@ const state = reactive({
   trailingStop: false,
 });
 
-/**
- * 선택된 계좌
- */
-const selectedAccount = ref('account1');
+const isAutoLiquidationOpen = ref(false); // 자동 청산 토글 상태
+const isBuyActive = ref(false); // 매수 버튼 토글 상태
+const isSellActive = ref(false); // 매도 버튼 토글 상태
+const selectedAccount = ref('account1'); // 선택된 계좌
+const isDropdownOpen = ref(false); // 드롭다운 토글 상태
 
-// 드롭다운 상태 관리
-const isDropdownOpen = ref(false);
-
-// 계좌 옵션 데이터
 const accountOptions = [
   { value: 'account1', label: '라이브계좌#1 110-81-345150' },
   { value: 'account2', label: '라이브계좌#2 110-81-345151' },
   { value: 'account3', label: '데모계좌#1 110-81-345152' },
 ];
 
-// 선택된 계좌의 라벨
 const selectedAccountLabel = computed(() => {
   const option = accountOptions.find((opt) => opt.value === selectedAccount.value);
   return option?.label || '계좌를 선택하세요';
 });
 
-// 드롭다운 토글
-const toggleDropdown = () => {
-  isDropdownOpen.value = !isDropdownOpen.value;
-};
-
-// 계좌 선택
 const selectAccount = (value: string) => {
   selectedAccount.value = value;
   isDropdownOpen.value = false;
 };
 
-// 외부 클릭 시 드롭다운 닫기
-onMounted(() => {
-  document.addEventListener('click', (e) => {
-    const target = e.target as HTMLElement;
-    if (!target.closest('.relative')) {
-      isDropdownOpen.value = false;
-    }
-  });
-});
-
-onUnmounted(() => {
-  document.removeEventListener('click', () => {});
-});
-
-const isBuyActive = ref(false);
-const isSellActive = ref(false);
-
-/**
- * 매수 버튼의 동적 클래스
- */
 const buyButtonClasses = computed(() => {
   const baseClasses = 'flex w-full flex-col items-center justify-center gap-1 rounded-md p-3 ';
 
@@ -457,9 +431,6 @@ const buyButtonClasses = computed(() => {
   return `${baseClasses} bg-[var(--button-red-background-none)]  text-[var(--base-colors-red-red800)]  `;
 });
 
-/**
- * 매도 버튼의 동적 클래스
- */
 const sellButtonClasses = computed(() => {
   const baseClasses = 'flex w-full flex-col items-center justify-center gap-1 rounded-md  p-3 ';
 
@@ -484,16 +455,10 @@ const handleSellClick = () => {
   isSellActive.value = !isSellActive.value;
 };
 
-/**
- * 선택된 주문 유형
- */
 const selectedOrderType = defineModel<string>('orderType', {
   default: 'market',
 });
 
-/**
- * 주문 유형 옵션들
- */
 const orderTypeOptions: RadioOption[] = [
   {
     value: 'market',

--- a/apps/sample-desktop/src/components/order/RightPanel.vue
+++ b/apps/sample-desktop/src/components/order/RightPanel.vue
@@ -51,22 +51,28 @@
     <div class="mt-2 flex gap-2">
       <button :class="buyButtonClasses" @click="handleBuyClick">
         <div class="text-font-14 font-medium leading-5 tracking-[-0.35px]">매수</div>
-        <div class="text-base font-semibold leading-5 tracking-[-0.35px]">1.17096</div>
+        <div class="text-base font-semibold leading-5 tracking-[-0.35px]">
+          {{ buyPrice.toFixed(5) }}
+        </div>
       </button>
       <button :class="sellButtonClasses" @click="handleSellClick">
         <div class="text-font-14 font-medium leading-5 tracking-[-0.35px]">매도</div>
-        <div class="text-base font-semibold leading-5 tracking-[-0.35px]">1.17096</div>
+        <div class="text-base font-semibold leading-5 tracking-[-0.35px]">
+          {{ sellPrice.toFixed(5) }}
+        </div>
       </button>
     </div>
 
     <!-- 매수 매도 진행바 -->
     <div class="mt-2 flex w-full flex-row items-start justify-start gap-2">
       <div
-        class="h-1.5 w-[218px] flex-shrink-0 rounded-[999px] bg-[var(--base-colors-red-red800)]"
+        class="h-1.5 rounded-[999px] bg-[var(--base-colors-red-red800)]"
+        :style="progressBarStyles.buyBarStyle"
       ></div>
-      <div class="h-1.5 min-w-0 flex-1">
-        <div class="bg-blue-blue800-deep h-1.5 w-full rounded-[999px]"></div>
-      </div>
+      <div
+        class="h-1.5 rounded-[999px] bg-[var(--base-colors-blue-blue800-deep)]"
+        :style="progressBarStyles.sellBarStyle"
+      ></div>
     </div>
 
     <!-- 거래 정보 섹션 -->
@@ -412,6 +418,40 @@ const isBuyActive = ref(false); // 매수 버튼 토글 상태
 const isSellActive = ref(false); // 매도 버튼 토글 상태
 const selectedAccount = ref('account1'); // 선택된 계좌
 const isDropdownOpen = ref(false); // 드롭다운 토글 상태
+
+// 매수/매도 가격 데이터
+const buyPrice = ref(1.171);
+const sellPrice = ref(1.17096);
+
+// 진행바 비율 계산
+const progressBarRatio = computed(() => {
+  const total = buyPrice.value + sellPrice.value;
+  const buyRatio = (buyPrice.value / total) * 100;
+  const sellRatio = (sellPrice.value / total) * 100;
+
+  return {
+    buyRatio,
+    sellRatio,
+  };
+});
+
+// 진행바 스타일 계산 (gap: 8px 유지)
+const progressBarStyles = computed(() => {
+  const { buyRatio, sellRatio } = progressBarRatio.value;
+
+  // 전체 너비에서 gap(8px)을 제외한 사용 가능한 너비
+  // flex로 처리되므로 비율로 계산
+  return {
+    buyBarStyle: {
+      width: `${buyRatio}%`,
+      flexShrink: 0,
+    },
+    sellBarStyle: {
+      width: `${sellRatio}%`,
+      flexShrink: 0,
+    },
+  };
+});
 
 const accountOptions = [
   { value: 'account1', label: '라이브계좌#1 110-81-345150' },

--- a/apps/sample-desktop/src/components/order/RightPanel.vue
+++ b/apps/sample-desktop/src/components/order/RightPanel.vue
@@ -39,7 +39,6 @@
           EURUSD
         </div>
       </div>
-      <div class="text-base font-semibold leading-5 tracking-[-0.35px] text-[#0067ef]">1.17100</div>
     </div>
 
     <!-- 주문 유형 선택 -->
@@ -89,28 +88,118 @@
     <!-- 수량 및 증거금율 섹션 -->
     <div class="mt-6 flex w-full flex-col gap-3">
       <!-- 수량 입력 섹션 -->
-      <div class="flex flex-col gap-1">
-        <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
-          수량(Lots)
-        </div>
-        <div class="flex h-[34px] w-[168px] items-center">
-          <!-- 수량 입력 필드 -->
-          <div class="flex-1 rounded-l-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2">
-            <div class="text-[14px] font-normal leading-[18px] text-[#131313]">1.0</div>
+      <div class="grid grid-cols-2 gap-2">
+        <!-- 시장가: 수량만 -->
+        <template v-if="selectedOrderType === 'market'">
+          <div class="flex min-w-0 flex-col gap-1">
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              수량(Lots)
+            </div>
+            <BaseInputStepper
+              v-model="quantity"
+              :min="0"
+              :max="100"
+              :step="0.01"
+              variant="default"
+            />
           </div>
-          <!-- 증가 버튼 -->
-          <div
-            class="flex items-center justify-center border border-[#b4b6bb] bg-white px-1 py-[9px]"
-          >
-            <BaseIcon name="plus" size="sm" />
+        </template>
+
+        <!-- Limit: 진입가격, 수량 -->
+        <template v-else-if="selectedOrderType === 'limit'">
+          <div class="flex min-w-0 flex-col gap-1">
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              진입가격 Pip
+            </div>
+            <BaseInputStepper
+              v-model="entryPrice"
+              :min="0"
+              :max="100"
+              :step="0.01"
+              variant="default"
+            />
           </div>
-          <!-- 감소 버튼 -->
-          <div
-            class="flex items-center justify-center rounded-r-[6px] border border-l-0 border-[#b4b6bb] bg-white px-1 py-[9px]"
-          >
-            <BaseIcon name="minus" size="sm" />
+          <div class="flex min-w-0 flex-col gap-1">
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              수량(Lots)
+            </div>
+            <BaseInputStepper
+              v-model="quantity"
+              :min="0"
+              :max="100"
+              :step="0.01"
+              variant="default"
+            />
           </div>
-        </div>
+        </template>
+
+        <!-- Stop: 배리어, 수량 -->
+        <template v-else-if="selectedOrderType === 'stop'">
+          <div class="flex min-w-0 flex-col gap-1">
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              배리어
+            </div>
+            <BaseInputStepper
+              v-model="barrier"
+              :min="0"
+              :max="100"
+              :step="0.01"
+              variant="default"
+            />
+          </div>
+          <div class="flex min-w-0 flex-col gap-1">
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              수량(Lots)
+            </div>
+            <BaseInputStepper
+              v-model="quantity"
+              :min="0"
+              :max="100"
+              :step="0.01"
+              variant="default"
+            />
+          </div>
+        </template>
+
+        <!-- Stop Limit: 배리어, 수량, 진입가격 -->
+        <template v-else-if="selectedOrderType === 'stopLimit'">
+          <div class="flex min-w-0 flex-col gap-1">
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              배리어
+            </div>
+            <BaseInputStepper
+              v-model="barrier"
+              :min="0"
+              :max="100"
+              :step="0.01"
+              variant="default"
+            />
+          </div>
+          <div class="flex min-w-0 flex-col gap-1">
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              수량(Lots)
+            </div>
+            <BaseInputStepper
+              v-model="quantity"
+              :min="0"
+              :max="100"
+              :step="0.01"
+              variant="default"
+            />
+          </div>
+          <div class="flex min-w-0 flex-col gap-1">
+            <div class="text-[14px] font-medium leading-[18px] tracking-[-0.35px] text-[#131313]">
+              진입가격 Pip
+            </div>
+            <BaseInputStepper
+              v-model="entryPrice"
+              :min="0"
+              :max="100"
+              :step="0.01"
+              variant="default"
+            />
+          </div>
+        </template>
       </div>
 
       <!-- 증거금율 정보 섹션 -->
@@ -178,89 +267,57 @@
 
         <!-- Stop Loss 입력 필드들 -->
         <div class="flex w-full flex-col gap-1">
-          <!-- 핍 입력 -->
+          <!-- Stop Loss 핍 입력 -->
           <div class="flex h-8 w-full items-center justify-between gap-1">
             <div class="flex h-full w-[150px] items-center">
-              <div
-                class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-              >
-                <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
-              </div>
-              <div
-                class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
-              >
-                <BaseIcon name="plus" size="sm" />
-              </div>
-              <div
-                class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-              >
-                <BaseIcon name="minus" size="sm" />
-              </div>
+              <BaseInputStepper
+                v-model="stopLossPip"
+                :max="100"
+                :step="0.00001"
+                variant="default"
+              />
             </div>
+
             <div
               class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
             >
               핍
             </div>
             <div class="flex h-full w-[150px] items-center">
-              <div
-                class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-              >
-                <div class="text-[13px] font-normal leading-[16px] text-[#131313]">-100.1</div>
-              </div>
-              <div
-                class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
-              >
-                <BaseIcon name="plus" size="sm" />
-              </div>
-              <div
-                class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-              >
-                <BaseIcon name="minus" size="sm" />
-              </div>
+              <BaseInputStepper
+                v-model="takeProfitPip"
+                :max="100"
+                :step="0.00001"
+                variant="default"
+              />
             </div>
           </div>
 
-          <!-- 가격 입력 -->
+          <!-- Stop Loss & Take Profit 가격 입력 -->
           <div class="flex h-8 w-full items-center justify-between gap-1">
             <div class="flex h-full w-[150px] items-center">
-              <div
-                class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-              >
-                <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
-              </div>
-              <div
-                class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
-              >
-                <BaseIcon name="plus" size="sm" />
-              </div>
-              <div
-                class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-              >
-                <BaseIcon name="minus" size="sm" />
-              </div>
+              <BaseInputStepper
+                v-model="stopLossPrice"
+                :min="0"
+                :max="100"
+                :step="0.00001"
+                variant="range"
+              />
             </div>
+
             <div
               class="w-10 text-center text-[12px] font-normal leading-[16px] tracking-[-0.35px] text-[#131313]"
             >
               가격
             </div>
             <div class="flex h-full w-[150px] items-center">
-              <div
-                class="flex-1 rounded-bl-[6px] rounded-tl-[6px] border border-r-0 border-[#b4b6bb] bg-white px-3 py-2"
-              >
-                <div class="text-[13px] font-normal leading-[16px] text-[#131313]">~1.18356</div>
-              </div>
-              <div
-                class="flex items-center justify-center border border-r-0 border-[#b4b6bb] bg-white px-1 py-2"
-              >
-                <BaseIcon name="plus" size="sm" />
-              </div>
-              <div
-                class="flex items-center justify-center rounded-br-[6px] rounded-tr-[6px] border border-[#b4b6bb] bg-white px-1 py-2"
-              >
-                <BaseIcon name="minus" size="sm" />
-              </div>
+              <BaseInputStepper
+                v-model="takeProfitPrice"
+                :min="0"
+                :max="100"
+                :step="0.00001"
+                variant="range"
+              />
             </div>
           </div>
         </div>
@@ -287,125 +344,16 @@
       </div>
 
       <!-- 호가 차트 -->
-      <div class="flex flex-col items-center gap-1">
-        <!-- 1단계 호가 -->
-        <div class="flex h-6 w-full gap-1">
-          <div class="flex h-6 w-full items-center justify-between text-xs">
-            <div class="relative z-10">1.00</div>
-            <div class="relative">
-              <div class="relative z-10 mr-[9px]">1.16790</div>
-              <div
-                class="absolute right-0 top-1/2 h-6 w-[5px] -translate-y-1/2 rounded bg-[#E0EDFF]"
-              ></div>
-            </div>
-          </div>
-          <div class="flex w-full items-center justify-between text-xs">
-            <div class="relative">
-              <div class="relative z-10 ml-[9px]">1.00</div>
-              <div
-                class="absolute left-0 top-1/2 h-6 w-[5px] -translate-y-1/2 rounded bg-[#FFDBDC]"
-              ></div>
-            </div>
-            <div class="relative z-10">1.16790</div>
-          </div>
-        </div>
-
-        <!-- 2단계 호가 -->
-        <div class="flex h-6 w-full gap-1">
-          <div class="flex h-6 w-full items-center justify-between text-xs">
-            <div class="relative z-10">1.00</div>
-            <div class="relative">
-              <div class="relative z-10 mr-[9px]">1.16790</div>
-              <div
-                class="absolute right-0 top-1/2 h-6 w-[40px] -translate-y-1/2 rounded bg-[#E0EDFF]"
-              ></div>
-            </div>
-          </div>
-          <div class="flex w-full items-center justify-between text-xs">
-            <div class="relative">
-              <div class="relative z-10 ml-[9px]">1.00</div>
-              <div
-                class="absolute left-0 top-1/2 h-6 w-[40px] -translate-y-1/2 rounded bg-[#FFDBDC]"
-              ></div>
-            </div>
-            <div class="relative z-10">1.16790</div>
-          </div>
-        </div>
-
-        <!-- 3단계 호가 -->
-        <div class="flex h-6 w-full gap-1">
-          <div class="flex h-6 w-full items-center justify-between text-xs">
-            <div class="relative z-10">1.00</div>
-            <div class="relative">
-              <div class="relative z-10 mr-[9px]">1.16790</div>
-              <div
-                class="absolute right-0 top-1/2 h-6 w-[60px] -translate-y-1/2 rounded bg-[#E0EDFF]"
-              ></div>
-            </div>
-          </div>
-          <div class="flex w-full items-center justify-between text-xs">
-            <div class="relative">
-              <div class="relative z-10 ml-[9px]">1.00</div>
-              <div
-                class="absolute left-0 top-1/2 h-6 w-[60px] -translate-y-1/2 rounded bg-[#FFDBDC]"
-              ></div>
-            </div>
-            <div class="relative z-10">1.16790</div>
-          </div>
-        </div>
-
-        <!-- 4단계 호가 -->
-        <div class="flex h-6 w-full gap-1">
-          <div class="flex h-6 w-full items-center justify-between text-xs">
-            <div class="relative z-10">1.00</div>
-            <div class="relative">
-              <div class="relative z-10 mr-[9px]">1.16790</div>
-              <div
-                class="absolute right-0 top-1/2 h-6 w-[100px] -translate-y-1/2 rounded bg-[#E0EDFF]"
-              ></div>
-            </div>
-          </div>
-          <div class="flex w-full items-center justify-between text-xs">
-            <div class="relative">
-              <div class="relative z-10 ml-[9px]">1.00</div>
-              <div
-                class="absolute left-0 top-1/2 h-6 w-[100px] -translate-y-1/2 rounded bg-[#FFDBDC]"
-              ></div>
-            </div>
-            <div class="relative z-10">1.16790</div>
-          </div>
-        </div>
-
-        <!-- 5단계 호가 -->
-        <div class="flex h-6 w-full gap-1">
-          <div class="flex h-6 w-full items-center justify-between text-xs">
-            <div class="relative z-10">1.00</div>
-            <div class="relative">
-              <div class="relative z-10 mr-[9px]">1.16790</div>
-              <div
-                class="absolute right-0 top-1/2 h-6 w-[150px] -translate-y-1/2 rounded bg-[#E0EDFF]"
-              ></div>
-            </div>
-          </div>
-          <div class="flex w-full items-center justify-between text-xs">
-            <div class="relative z-10">
-              <div class="relative z-10 ml-[9px]">1.00</div>
-              <div
-                class="absolute left-0 top-1/2 h-6 w-[150px] -translate-y-1/2 rounded bg-[#FFDBDC]"
-              ></div>
-            </div>
-            <div class="relative z-10">1.16790</div>
-          </div>
-        </div>
-      </div>
+      <OrderBook />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { BaseRadioGroup, BaseButton, BaseIcon, BaseCheckbox, BaseProgressBar } from '@template/ui';
+import { BaseRadioGroup, BaseButton, BaseIcon, BaseCheckbox, BaseInputStepper } from '@template/ui';
 import type { RadioOption } from '@template/ui';
 import { reactive, ref, computed } from 'vue';
+import OrderBook from './OrderBook.vue';
 
 const state = reactive({
   stopLoss: false,
@@ -423,6 +371,17 @@ const isDropdownOpen = ref(false); // 드롭다운 토글 상태
 const buyPrice = ref(1.171);
 const sellPrice = ref(1.17096);
 
+// 주문 입력 데이터
+const quantity = ref(0);
+const entryPrice = ref(0);
+const barrier = ref(0);
+
+// Stop Loss & Take Profit 데이터
+const stopLossPip = ref(0);
+const stopLossPrice = ref(0);
+const takeProfitPip = ref(0);
+const takeProfitPrice = ref(0);
+
 // 진행바 비율 계산
 const progressBarRatio = computed(() => {
   const total = buyPrice.value + sellPrice.value;
@@ -439,8 +398,6 @@ const progressBarRatio = computed(() => {
 const progressBarStyles = computed(() => {
   const { buyRatio, sellRatio } = progressBarRatio.value;
 
-  // 전체 너비에서 gap(8px)을 제외한 사용 가능한 너비
-  // flex로 처리되므로 비율로 계산
   return {
     buyBarStyle: {
       width: `${buyRatio}%`,

--- a/apps/sample-desktop/src/views/order/Index.vue
+++ b/apps/sample-desktop/src/views/order/Index.vue
@@ -81,7 +81,8 @@
           <!-- 우측 패널: 주문 처리 (25%) -->
           <template #second>
             <div class="order-action-panel">
-              <div class="panel-header">
+              <RightPanel />
+              <!-- <div class="panel-header">
                 <h2 class="panel-title">⚡ 주문 패널</h2>
                 <p class="panel-subtitle">주문 상태 변경 및 액션 패널</p>
               </div>
@@ -90,7 +91,7 @@
                   <div class="placeholder-icon">⚡</div>
                   <p>주문 처리 옵션이 여기에 표시됩니다</p>
                 </div>
-              </div>
+              </div> -->
             </div>
           </template>
         </BaseTwoWaySplitPane>
@@ -102,6 +103,7 @@
 <script setup lang="ts">
 import TradingViewChart from '@/components/chart/TradingViewChart.vue';
 import { BaseTwoWaySplitPane, BaseTable } from '@template/ui';
+import RightPanel from '@/components/order/RightPanel.vue';
 import type { TableHeader, TableRow } from '@template/ui';
 
 const orderTableHeaders: TableHeader[] = [

--- a/packages/ui/src/components/BaseButton/BaseButton.vue
+++ b/packages/ui/src/components/BaseButton/BaseButton.vue
@@ -138,7 +138,7 @@ const buttonClasses = computed(() => {
   if (props.disabled) classes.push('btn-disabled');
   if (props.pill) classes.push('btn-pill');
   // customClass가 없을 때만 color 클래스 적용
-  if (!props.customClass && predefinedColors.includes(props.color as ButtonColor)) {
+  if (predefinedColors.includes(props.color as ButtonColor)) {
     classes.push(`btn-color-${props.color}`);
   }
   // customClass는 항상 마지막에 push (우선순위 보장)

--- a/packages/ui/src/components/BaseInput/BaseInputStepper.vue
+++ b/packages/ui/src/components/BaseInput/BaseInputStepper.vue
@@ -4,8 +4,7 @@
 -->
 <script setup lang="ts">
 import BaseIcon from '../BaseIcon/BaseIcon.vue';
-import BaseInput from './BaseInput.vue';
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 /**
  * BaseInputStepper - 스테퍼 입력 컴포넌트
@@ -14,11 +13,11 @@ import { computed } from 'vue';
  * @props placeholder - 플레이스홀더 텍스트
  * @props size - 크기 (sm, md)
  * @props disabled - 비활성화 여부
- * @props error - 에러 상태 여부
- * @props errorMessage - 에러 메시지
- * @props min - 최소값
- * @props max - 최대값
- * @props step - 증감 단위
+ * @props min - 최소값 (기본: 제한 없음, 음수 가능)
+ * @props max - 최대값 (기본: 제한 없음)
+ * @props step - 증감 단위 (기본: 0.00001)
+ * @props variant - 표시 형식: 기본값(default) | 단위(unit) | 범위(range)
+ * @props unitLabel - variant가 unit일 때 뒤에 표시할 단위 문자열 (기본: 'Lot')
  * @emits update:modelValue - 값 변경 시 발생
  * @emits focus - 포커스 시 발생
  * @emits blur - 블러 시 발생
@@ -43,40 +42,40 @@ interface Props {
    */
   disabled?: boolean;
   /**
-   * 에러 상태 여부
-   * @default false
-   */
-  error?: boolean;
-  /**
-   * 에러 메시지
-   */
-  errorMessage?: string;
-  /**
-   * 최소값
-   * @default 0
+   * 최소값 (기본: 제한 없음, 음수 가능)
    */
   min?: number;
   /**
-   * 최대값
+   * 최대값 (기본: 제한 없음)
    */
   max?: number;
   /**
    * 증감 단위
-   * @default 1
+   * @default 0.00001
    */
   step?: number;
+  /**
+   * 표시 형식: 기본(default) | 단위(unit) | 범위(range)
+   * @default 'default'
+   */
+  variant?: 'default' | 'unit' | 'range';
+  /**
+   * 단위 표시 텍스트 (variant가 'unit'일 때 사용)
+   * @default 'Lot'
+   */
+  unitLabel?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  modelValue: 0,
+  modelValue: undefined,
   placeholder: '',
   size: 'sm',
   disabled: false,
-  error: false,
-  errorMessage: '',
-  min: 0,
+  min: undefined,
   max: undefined,
-  step: 1,
+  step: 0.00001,
+  variant: 'default',
+  unitLabel: 'Lot',
 });
 
 const emit = defineEmits<{
@@ -85,42 +84,114 @@ const emit = defineEmits<{
   (e: 'blur', event: FocusEvent): void;
 }>();
 
+// 로컬 상태로 값 관리 (초기값 처리 개선)
+const localValue = ref(props.modelValue ?? 0);
+
+// props.modelValue 변경 시 로컬 상태 동기화
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    localValue.value = newValue ?? 0;
+  }
+);
+
 // 아이콘 크기 계산
 const iconSize = computed(() => {
   return props.size === 'sm' ? 'sm' : 'md';
 });
 
-// 최소/최대값 체크
+// 최소/최대값 체크 (음수 지원 개선)
 const canDecrease = computed(() => {
-  return !props.disabled && (props.max === undefined || props.modelValue > props.min);
+  if (props.disabled) return false;
+  // min이 설정되어 있을 때만 체크: 감소 후 값이 min보다 작아지면 감소 불가
+  if (props.min !== undefined && localValue.value - props.step < props.min) return false;
+  return true;
 });
 
 const canIncrease = computed(() => {
-  return !props.disabled && (props.max === undefined || props.modelValue < props.max);
+  if (props.disabled) return false;
+  // max가 설정되어 있을 때만 체크: 증가 후 값이 max보다 커지면 증가 불가
+  if (props.max !== undefined && localValue.value + props.step > props.max) return false;
+  return true;
 });
 
-// 이벤트 핸들러
-const handleInput = (value: string) => {
-  const numValue = parseInt(value) || 0;
-  emit('update:modelValue', numValue);
+const handleInput = (event: Event) => {
+  const input = event.target as HTMLInputElement;
+  const value = input.value;
+
+  // 숫자, 소수점, 음수 기호만 허용하는 정규식
+  const validPattern = /^-?(\d+)?\.?\d*$/;
+
+  // 유효하지 않은 문자 제거
+  let cleanValue = value.replace(/[^0-9.-]/g, '');
+
+  // 음수 기호(-) 처리: 맨 앞에만 허용
+  if (cleanValue.indexOf('-') > 0) {
+    cleanValue = cleanValue.replace(/-/g, '');
+  }
+
+  // 소수점(.) 처리: 하나만 허용
+  const dotCount = (cleanValue.match(/\./g) || []).length;
+  if (dotCount > 1) {
+    const firstDotIndex = cleanValue.indexOf('.');
+    cleanValue =
+      cleanValue.substring(0, firstDotIndex + 1) +
+      cleanValue.substring(firstDotIndex + 1).replace(/\./g, '');
+  }
+
+  // 입력값이 변경되었으면 input 값 업데이트
+  if (value !== cleanValue) {
+    input.value = cleanValue;
+  }
+
+  // 빈 값이나 '-'만 있는 경우 처리
+  if (cleanValue === '' || cleanValue === '-') {
+    localValue.value = 0;
+    return;
+  }
+
+  // 숫자 파싱 및 검증
+  const numValue = parseFloat(cleanValue);
+  if (!Number.isFinite(numValue)) {
+    // 잘못된 입력은 무시하고 이전 값 유지
+    return;
+  }
+
+  // 범위 제한 적용
+  const clampedValue = clampToRange(numValue);
+  localValue.value = clampedValue;
+  emit('update:modelValue', clampedValue);
 };
 
-const handleDecrease = () => {
-  if (canDecrease.value) {
-    const newValue = props.modelValue - props.step;
-    emit('update:modelValue', Math.max(newValue, props.min));
-  }
+const clampToRange = (value: number) => {
+  let v = value;
+  if (props.min !== undefined) v = Math.max(v, props.min);
+  if (props.max !== undefined) v = Math.min(v, props.max);
+  return v;
 };
 
-const handleIncrease = () => {
-  if (canIncrease.value) {
-    const newValue = props.modelValue + props.step;
-    if (props.max !== undefined) {
-      emit('update:modelValue', Math.min(newValue, props.max));
-    } else {
-      emit('update:modelValue', newValue);
-    }
+const handleDecrease = (event?: Event) => {
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
   }
+  if (!canDecrease.value) return;
+  const newValue = localValue.value - props.step;
+  const clampedValue = clampToRange(newValue);
+  localValue.value = clampedValue;
+  emit('update:modelValue', clampedValue);
+};
+
+const handleIncrease = (event?: Event) => {
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  if (!canIncrease.value) return;
+  const newValue = localValue.value + props.step;
+  const clampedValue = clampToRange(newValue);
+  localValue.value = clampedValue;
+  emit('update:modelValue', clampedValue);
 };
 
 const handleFocus = (event: FocusEvent) => {
@@ -130,43 +201,131 @@ const handleFocus = (event: FocusEvent) => {
 const handleBlur = (event: FocusEvent) => {
   emit('blur', event);
 };
+
+// 숫자, 소수점, 음수 기호만 허용하는 키보드 입력 제한
+const handleKeydown = (event: KeyboardEvent) => {
+  const key = event.key;
+  const currentValue = (event.target as HTMLInputElement).value;
+
+  // 허용되는 키들: 숫자, 백스페이스, 삭제, 탭, 화살표, 엔터, 이스케이프
+  const allowedKeys = [
+    'Backspace',
+    'Delete',
+    'Tab',
+    'Escape',
+    'Enter',
+    'ArrowLeft',
+    'ArrowRight',
+    'ArrowUp',
+    'ArrowDown',
+    'Home',
+    'End',
+  ];
+
+  // 허용된 키는 통과
+  if (allowedKeys.includes(key)) {
+    return;
+  }
+
+  // 숫자 (0-9) 허용
+  if (/^[0-9]$/.test(key)) {
+    return;
+  }
+
+  // 소수점 (.) 허용 (이미 있으면 차단)
+  if (key === '.' && !currentValue.includes('.')) {
+    return;
+  }
+
+  // 음수 기호 (-) 허용 (맨 앞에만, 이미 있으면 차단)
+  if (
+    key === '-' &&
+    !currentValue.includes('-') &&
+    (event.target as HTMLInputElement).selectionStart === 0
+  ) {
+    return;
+  }
+
+  // 그 외 모든 입력 차단
+  event.preventDefault();
+};
+
+// 소수점 자릿수 계산 (step에 따라 자동 계산)
+const decimalPlaces = computed(() => {
+  const stepStr = props.step.toString();
+  const decimalIndex = stepStr.indexOf('.');
+  return decimalIndex === -1 ? 0 : stepStr.length - decimalIndex - 1;
+});
+
+// 포맷된 값 표시
+const formattedValue = computed(() => {
+  return localValue.value.toFixed(decimalPlaces.value);
+});
+
+// 입력 필드용 값 (순수 숫자만)
+const inputValue = computed(() => {
+  return formattedValue.value;
+});
 </script>
 
 <template>
-  <BaseInput
-    :model-value="modelValue.toString()"
-    :placeholder="placeholder"
-    :size="size"
-    :disabled="disabled"
-    :error="error"
-    :error-message="errorMessage"
-    type="number"
-    :min="min"
-    :max="max"
-    :step="step"
-    @update:model-value="handleInput"
-    @focus="handleFocus"
-    @blur="handleBlur"
-  >
-    <template #suffix>
-      <div class="base-input-stepper-controls">
-        <button
-          type="button"
-          class="base-input-stepper-btn"
-          :disabled="!canDecrease"
-          @click="handleDecrease"
-        >
-          <BaseIcon name="minus" :size="iconSize" :color="canDecrease ? 'default' : 'disabled'" />
-        </button>
-        <button
-          type="button"
-          class="base-input-stepper-btn"
-          :disabled="!canIncrease"
-          @click="handleIncrease"
-        >
-          <BaseIcon name="plus" :size="iconSize" :color="canIncrease ? 'default' : 'disabled'" />
-        </button>
-      </div>
-    </template>
-  </BaseInput>
+  <div class="flex h-[34px] w-full items-center">
+    <!-- Range prefix (variant='range'일 때) -->
+    <div
+      v-if="variant === 'range'"
+      class="flex select-none items-center justify-center rounded-l-[6px] border border-r-0 border-[#b4b6bb] bg-white py-2 pl-3 text-[14px] font-normal leading-[18px] text-[#131313]"
+    >
+      ~
+    </div>
+
+    <!-- 숫자 입력 필드 -->
+    <input
+      type="text"
+      inputmode="decimal"
+      class="min-w-0 flex-1 border border-[#b4b6bb] bg-white px-3 py-2 text-[14px] font-normal leading-[18px] text-[#131313] focus:outline-none"
+      :class="{
+        'cursor-not-allowed opacity-50': disabled,
+        'rounded-l-[6px] border-r-0': variant === 'default' || variant === 'unit',
+        'border-r-0': variant === 'range' || variant === 'unit',
+        'border-l-0': variant === 'range',
+      }"
+      :value="inputValue"
+      :placeholder="placeholder"
+      :disabled="disabled"
+      @input="handleInput"
+      @keydown="handleKeydown"
+      @focus="handleFocus"
+      @blur="handleBlur"
+    />
+
+    <!-- Unit suffix (variant='unit'일 때) -->
+    <div
+      v-if="variant === 'unit'"
+      class="flex select-none items-center justify-center border border-l-0 border-r-0 border-[#b4b6bb] bg-white px-3 py-2 text-[14px] font-normal leading-[18px] text-[#131313]"
+    >
+      {{ unitLabel }}
+    </div>
+
+    <!-- 증가 버튼 -->
+    <div
+      class="flex cursor-pointer items-center justify-center border border-[#b4b6bb] bg-white px-1 py-[9px] transition-colors hover:bg-gray-50"
+      :class="{
+        'cursor-not-allowed opacity-50': !canIncrease,
+      }"
+      @mousedown="handleIncrease"
+      @click.prevent.stop
+    >
+      <BaseIcon name="plus" :size="iconSize" style="pointer-events: none" />
+    </div>
+
+    <!-- 감소 버튼 -->
+    <div
+      class="flex cursor-pointer items-center justify-center rounded-r-[6px] border border-l-0 border-[#b4b6bb] bg-white px-1 py-[9px] transition-colors hover:bg-gray-50"
+      :class="{ 'cursor-not-allowed opacity-50': !canDecrease }"
+      @mousedown="handleDecrease"
+      @click.prevent.stop
+    >
+      <BaseIcon name="minus" :size="iconSize" style="pointer-events: none" />
+    </div>
+  </div>
 </template>

--- a/packages/ui/src/components/BaseInput/index.ts
+++ b/packages/ui/src/components/BaseInput/index.ts
@@ -1,1 +1,2 @@
 export { default as BaseInput } from './BaseInput.vue';
+export { default as BaseInputStepper } from './BaseInputStepper.vue';

--- a/packages/ui/src/components/BaseInput/stories/BaseInputStepper.stories.ts
+++ b/packages/ui/src/components/BaseInput/stories/BaseInputStepper.stories.ts
@@ -8,7 +8,7 @@ const meta: Meta<typeof BaseInputStepper> = {
     docs: {
       description: {
         component:
-          '스테퍼 입력 컴포넌트입니다. 피그마의 Input/Stepper와 Input/Stepper-lined 디자인을 기반으로 구현되었으며, +/- 버튼으로 값을 조정할 수 있습니다.',
+          '스테퍼 입력 컴포넌트입니다. 피그마의 Input/Stepper와 Input/Stepper-lined 디자인을 기반으로 구현되었으며, +/- 버튼으로 값을 조정할 수 있습니다. step prop으로 증감 단위를 조절할 수 있습니다.',
       },
     },
   },
@@ -30,14 +30,6 @@ const meta: Meta<typeof BaseInputStepper> = {
       description: '비활성화 여부',
       control: 'boolean',
     },
-    error: {
-      description: '에러 상태 여부',
-      control: 'boolean',
-    },
-    errorMessage: {
-      description: '에러 메시지',
-      control: 'text',
-    },
     min: {
       description: '최소값',
       control: 'number',
@@ -47,8 +39,18 @@ const meta: Meta<typeof BaseInputStepper> = {
       control: 'number',
     },
     step: {
-      description: '증감 단위',
+      description: '증감 단위 (기본값: 0.00001)',
       control: 'number',
+    },
+    // 새로 추가된 props
+    variant: {
+      description: "표시 형식: 'default' | 'unit' | 'range'",
+      control: 'select',
+      options: ['default', 'unit', 'range'],
+    },
+    unitLabel: {
+      description: "단위 텍스트 (variant='unit'일 때 사용)",
+      control: 'text',
     },
   },
   tags: ['autodocs'],
@@ -57,27 +59,26 @@ const meta: Meta<typeof BaseInputStepper> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// 기본 스토리
+// 기본 스토리 (0.00001 단위)
 export const Default: Story = {
   args: {
-    modelValue: 0,
-    placeholder: '수량을 입력하세요',
+    modelValue: 1.17,
+    placeholder: '가격을 입력하세요',
     size: 'sm',
-    min: 0,
-    max: 100,
-    step: 1,
+    max: 10,
+    step: 0.00001,
   },
 };
 
 // 값이 있는 상태
 export const WithValue: Story = {
   args: {
-    modelValue: 5,
-    placeholder: '수량을 입력하세요',
+    modelValue: 1.171,
+    placeholder: '가격을 입력하세요',
     size: 'sm',
     min: 0,
-    max: 100,
-    step: 1,
+    max: 10,
+    step: 0.00001,
   },
 };
 
@@ -85,74 +86,85 @@ export const WithValue: Story = {
 export const AtMinimum: Story = {
   args: {
     modelValue: 0,
-    placeholder: '수량을 입력하세요',
+    placeholder: '가격을 입력하세요',
     size: 'sm',
     min: 0,
-    max: 100,
-    step: 1,
+    max: 10,
+    step: 0.00001,
   },
 };
 
 // 최대값에 도달한 상태
 export const AtMaximum: Story = {
   args: {
-    modelValue: 100,
-    placeholder: '수량을 입력하세요',
+    modelValue: 10,
+    placeholder: '가격을 입력하세요',
     size: 'sm',
     min: 0,
-    max: 100,
-    step: 1,
+    max: 10,
+    step: 0.00001,
   },
 };
 
 // 비활성화 상태
 export const Disabled: Story = {
   args: {
-    modelValue: 5,
+    modelValue: 1.171,
     placeholder: '비활성화된 스테퍼',
     size: 'sm',
     disabled: true,
     min: 0,
-    max: 100,
-    step: 1,
+    max: 10,
+    step: 0.00001,
   },
 };
 
-// 에러 상태
-export const Error: Story = {
-  args: {
-    modelValue: 0,
-    placeholder: '에러가 있는 스테퍼',
-    size: 'sm',
-    error: true,
-    errorMessage: '수량을 입력해주세요.',
-    min: 0,
-    max: 100,
-    step: 1,
-  },
-};
 
-// 큰 단위 스테퍼
+// 큰 단위 스테퍼 (1씩 증가)
 export const LargeStep: Story = {
   args: {
-    modelValue: 50,
+    modelValue: 5,
     placeholder: '큰 단위 스테퍼',
     size: 'sm',
     min: 0,
-    max: 1000,
-    step: 10,
+    max: 100,
+    step: 1,
   },
 };
 
-// 소수점 스테퍼
+// 소수점 스테퍼 (0.5씩 증가)
 export const DecimalStep: Story = {
   args: {
-    modelValue: 1.5,
+    modelValue: 2.5,
     placeholder: '소수점 스테퍼',
     size: 'sm',
     min: 0,
     max: 10,
     step: 0.5,
+  },
+};
+
+// 매우 작은 단위 스테퍼 (0.00001씩 증가)
+export const MicroStep: Story = {
+  args: {
+    modelValue: 1.17,
+    placeholder: '마이크로 단위 스테퍼',
+    size: 'sm',
+    min: 1.17,
+    max: 1.172,
+    step: 0.00001,
+  },
+};
+
+// 중간 단위 스테퍼 (0.001씩 증가)
+export const MediumStep: Story = {
+  args: {
+    modelValue: 1.17,
+    placeholder: '중간 단위 스테퍼',
+    size: 'sm',
+    min: 1.17,
+    max: 1.18,
+    step: 0.001,
   },
 };
 
@@ -175,65 +187,51 @@ export const AllStates: Story = {
     template: `
       <div style="display: flex; flex-direction: column; gap: 16px; max-width: 400px;">
         <div>
-          <h4 style="margin-bottom: 8px; color: #131313;">기본 상태</h4>
+          <h4 style="margin-bottom: 8px; color: #131313;">기본 상태 (0.00001 단위)</h4>
           <BaseInputStepper 
-            model-value="5" 
+            :model-value="1.17100" 
             placeholder="기본 스테퍼" 
             size="sm" 
             :min="0" 
-            :max="100" 
-            :step="1" 
+            :max="10" 
+            :step="0.00001" 
           />
         </div>
         
         <div>
           <h4 style="margin-bottom: 8px; color: #131313;">최소값 상태</h4>
           <BaseInputStepper 
-            model-value="0" 
+            :model-value="0" 
             placeholder="최소값 스테퍼" 
             size="sm" 
             :min="0" 
-            :max="100" 
-            :step="1" 
+            :max="10" 
+            :step="0.00001" 
           />
         </div>
         
         <div>
           <h4 style="margin-bottom: 8px; color: #131313;">최대값 상태</h4>
           <BaseInputStepper 
-            model-value="100" 
+            :model-value="10" 
             placeholder="최대값 스테퍼" 
             size="sm" 
             :min="0" 
-            :max="100" 
-            :step="1" 
-          />
-        </div>
-        
-        <div>
-          <h4 style="margin-bottom: 8px; color: #131313;">에러 상태</h4>
-          <BaseInputStepper 
-            model-value="0" 
-            placeholder="에러가 있는 스테퍼" 
-            size="sm" 
-            :error="true" 
-            error-message="수량을 입력해주세요." 
-            :min="0" 
-            :max="100" 
-            :step="1" 
+            :max="10" 
+            :step="0.00001" 
           />
         </div>
         
         <div>
           <h4 style="margin-bottom: 8px; color: #131313;">비활성화 상태</h4>
           <BaseInputStepper 
-            model-value="5" 
+            :model-value="1.17100" 
             placeholder="비활성화된 스테퍼" 
             size="sm" 
             :disabled="true" 
             :min="0" 
-            :max="100" 
-            :step="1" 
+            :max="10" 
+            :step="0.00001" 
           />
         </div>
       </div>
@@ -248,21 +246,21 @@ export const UsageExample: Story = {
     template: `
       <div style="display: flex; flex-direction: column; gap: 20px; max-width: 400px;">
         <div>
-          <h4 style="margin-bottom: 8px; color: #131313;">수량 선택</h4>
+          <h4 style="margin-bottom: 8px; color: #131313;">외환 가격 조절 (0.00001 단위)</h4>
           <BaseInputStepper 
-            model-value="1" 
-            placeholder="수량을 선택하세요" 
+            :model-value="1.17100" 
+            placeholder="가격을 설정하세요" 
             size="sm" 
-            :min="1" 
-            :max="99" 
-            :step="1" 
+            :min="1.17000" 
+            :max="1.17200" 
+            :step="0.00001" 
           />
         </div>
         
         <div>
-          <h4 style="margin-bottom: 8px; color: #131313;">온도 조절</h4>
+          <h4 style="margin-bottom: 8px; color: #131313;">온도 조절 (1도 단위)</h4>
           <BaseInputStepper 
-            model-value="20" 
+            :model-value="20" 
             placeholder="온도를 설정하세요" 
             size="sm" 
             :min="16" 
@@ -272,9 +270,9 @@ export const UsageExample: Story = {
         </div>
         
         <div>
-          <h4 style="margin-bottom: 8px; color: #131313;">볼륨 조절</h4>
+          <h4 style="margin-bottom: 8px; color: #131313;">볼륨 조절 (5씩 증가)</h4>
           <BaseInputStepper 
-            model-value="50" 
+            :model-value="50" 
             placeholder="볼륨을 설정하세요" 
             size="sm" 
             :min="0" 
@@ -294,9 +292,33 @@ export const DifferentSteps: Story = {
     template: `
       <div style="display: flex; flex-direction: column; gap: 16px; max-width: 400px;">
         <div>
-          <h4 style="margin-bottom: 8px; color: #131313;">1씩 증가 (기본)</h4>
+          <h4 style="margin-bottom: 8px; color: #131313;">0.00001씩 증가 (기본)</h4>
           <BaseInputStepper 
-            model-value="5" 
+            :model-value="1.17100" 
+            placeholder="0.00001씩 증가" 
+            size="sm" 
+            :min="1.17000" 
+            :max="1.17200" 
+            :step="0.00001" 
+          />
+        </div>
+        
+        <div>
+          <h4 style="margin-bottom: 8px; color: #131313;">0.001씩 증가</h4>
+          <BaseInputStepper 
+            :model-value="1.170" 
+            placeholder="0.001씩 증가" 
+            size="sm" 
+            :min="1.170" 
+            :max="1.180" 
+            :step="0.001" 
+          />
+        </div>
+        
+        <div>
+          <h4 style="margin-bottom: 8px; color: #131313;">1씩 증가</h4>
+          <BaseInputStepper 
+            :model-value="5" 
             placeholder="1씩 증가" 
             size="sm" 
             :min="0" 
@@ -308,7 +330,7 @@ export const DifferentSteps: Story = {
         <div>
           <h4 style="margin-bottom: 8px; color: #131313;">5씩 증가</h4>
           <BaseInputStepper 
-            model-value="25" 
+            :model-value="25" 
             placeholder="5씩 증가" 
             size="sm" 
             :min="0" 
@@ -316,28 +338,152 @@ export const DifferentSteps: Story = {
             :step="5" 
           />
         </div>
-        
+      </div>
+    `,
+  }),
+};
+
+// 외환 거래 예시
+export const ForexTradingExample: Story = {
+  render: () => ({
+    components: { BaseInputStepper },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 20px; max-width: 400px;">
         <div>
-          <h4 style="margin-bottom: 8px; color: #131313;">10씩 증가</h4>
+          <h4 style="margin-bottom: 8px; color: #131313;">EUR/USD 가격 설정</h4>
           <BaseInputStepper 
-            model-value="50" 
-            placeholder="10씩 증가" 
+            :model-value="1.17100" 
+            placeholder="EUR/USD 가격" 
             size="sm" 
-            :min="0" 
-            :max="100" 
-            :step="10" 
+            :min="1.17000" 
+            :max="1.17200" 
+            :step="0.00001" 
           />
         </div>
         
         <div>
-          <h4 style="margin-bottom: 8px; color: #131313;">0.5씩 증가</h4>
+          <h4 style="margin-bottom: 8px; color: #131313;">GBP/USD 가격 설정</h4>
           <BaseInputStepper 
-            model-value="2.5" 
-            placeholder="0.5씩 증가" 
+            :model-value="1.25000" 
+            placeholder="GBP/USD 가격" 
             size="sm" 
-            :min="0" 
-            :max="10" 
-            :step="0.5" 
+            :min="1.24000" 
+            :max="1.26000" 
+            :step="0.00001" 
+          />
+        </div>
+        
+        <div>
+          <h4 style="margin-bottom: 8px; color: #131313;">USD/JPY 가격 설정</h4>
+          <BaseInputStepper 
+            :model-value="150.000" 
+            placeholder="USD/JPY 가격" 
+            size="sm" 
+            :min="149.000" 
+            :max="151.000" 
+            :step="0.001" 
+          />
+        </div>
+      </div>
+    `,
+  }),
+};
+
+// 단위 표시 (variant: 'unit')
+export const UnitVariant: Story = {
+  args: {
+    modelValue: 1.5,
+    placeholder: '수량',
+    size: 'sm',
+    step: 0.1,
+    variant: 'unit',
+    unitLabel: 'Lot',
+  },
+};
+
+// 범위 표시 (variant: 'range')
+export const RangeVariant: Story = {
+  args: {
+    modelValue: 100.1,
+    placeholder: '상한값',
+    size: 'sm',
+    step: 0.1,
+    variant: 'range',
+  },
+};
+
+// 음수 값 허용 (기본 동작)
+export const NegativeValues: Story = {
+  args: {
+    modelValue: -100.1,
+    placeholder: '손익 값',
+    size: 'sm',
+    // min과 max를 지정하지 않으면 음수/양수 모두 허용
+    step: 0.1,
+  },
+};
+
+// 모든 variants 비교
+export const AllVariants: Story = {
+  render: () => ({
+    components: { BaseInputStepper },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 20px; max-width: 400px;">
+        <div>
+          <h4 style="margin-bottom: 8px; color: #131313;">기본 (Default)</h4>
+          <BaseInputStepper 
+            :model-value="1.23456" 
+            placeholder="기본 형식" 
+            size="sm" 
+            :step="0.00001" 
+            variant="default"
+          />
+        </div>
+        
+        <div>
+          <h4 style="margin-bottom: 8px; color: #131313;">단위 표시 (Unit)</h4>
+          <BaseInputStepper 
+            :model-value="1.5" 
+            placeholder="단위 형식" 
+            size="sm" 
+            :step="0.1" 
+            variant="unit"
+            unit-label="Lot"
+          />
+        </div>
+        
+        <div>
+          <h4 style="margin-bottom: 8px; color: #131313;">범위 표시 (Range)</h4>
+          <BaseInputStepper 
+            :model-value="100.1" 
+            placeholder="범위 형식" 
+            size="sm" 
+            :step="0.1" 
+            variant="range"
+          />
+        </div>
+        
+        <div>
+          <h4 style="margin-bottom: 8px; color: #131313;">음수 허용</h4>
+          <BaseInputStepper 
+            :model-value="-50" 
+            placeholder="음수 허용" 
+            size="sm" 
+            :step="1" 
+            variant="default"
+          />
+        </div>
+        
+        <div>
+          <h4 style="margin-bottom: 8px; color: #131313;">범위 제한 (음수 범위)</h4>
+          <BaseInputStepper 
+            :model-value="-5" 
+            placeholder="음수 범위" 
+            size="sm" 
+            :min="-10"
+            :max="10"
+            :step="1" 
+            variant="default"
           />
         </div>
       </div>

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -12,6 +12,7 @@ export { default as BaseStepper } from './BaseStepper/BaseStepper.vue';
 export { default as BaseSwitch } from './BaseSwitch/BaseSwitch.vue';
 export { default as BaseRadioGroup } from './BaseRadioGroup/BaseRadioGroup.vue';
 export { default as BaseTwoWaySplitPane } from './BaseTwoWaySplitPane/BaseTwoWaySplitPane.vue';
+export { default as BaseInputStepper } from './BaseInput/BaseInputStepper.vue';
 
 export * from './BasePagination';
 export * from './BaseTable';


### PR DESCRIPTION
### 화면 기획
- 매수 혹은 매도 버튼이 눌려야만 주문실행 버튼 활성화
- 자동청산 영역 토글기능 적용


### 개선되어야 할 사항
- BaseRadioGroup : 화면마다 선택된 영역의 px 값이 다름을 확인했습니다. 고민 후 반영하겠습니다.


## 주요 변경사항
### 1. 주문 우측 패널 1차 작업 (92a193b)
새로운 RightPanel.vue 컴포넌트 생성
통화 페어 표시 섹션 (EURUSD, 가격 정보)
주문 유형 선택을 위한 라디오 그룹
매도/매수 버튼 구현
거래 정보 표시 (스프레드, 고가, 저가)
수량 입력 필드 및 증거금율 정보
자동 청산 섹션 기본 구조

### 2. 패널 selectbox 및 버튼 토글 작업 (f2f1a1b)
계좌 선택을 위한 드롭다운 구현
드롭다운 토글 기능 추가
버튼 상태 관리 로직 구현

### 3. 코드 리팩토링 (d7dd60a)
토글 함수를 인라인으로 단순화
자동 청산 섹션 토글 기능 개선
전반적인 코드 구조 정리

### 4. 매수매도 진행바 작업 (48e4092)
기존 BaseProgressBar를 커스텀 진행바로 교체
빨간색(매도)과 파란색(매수) 진행바 구현
Figma 디자인과 일치하는 시각적 표현

| 기본 | 상단 selectbox 클릭 |
|-------|-------|
| ![이미지1](https://github.com/user-attachments/assets/f491638d-b4ef-47fc-95a2-c3455ae94147) | ![이미지2](https://github.com/user-attachments/assets/d4c52efa-1ac6-4e5e-840c-0747a6ecb101) |

| 자동청산 영역 토글 | 매수-매도 버튼 클릭 |
|-------|-------|
| ![이미지1](https://github.com/user-attachments/assets/9b586166-ec9d-44a9-9c5d-e3b4c7dfa89d) | ![이미지2](https://github.com/user-attachments/assets/b458f754-18cb-45c1-8ae6-dc0e6e68f7e6) |




