### PR TITLE
chore: vue inspector 초기 로딩 시 비활성화

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -13,10 +13,9 @@ export default defineConfig(({ mode }) => {
     ...commonConfig,
     plugins: [
       vue(),
-      // Vue Inspector - 개발 모드에서만 활성화
       VueInspector({
         toggleComboKey: 'alt',
-        enabled: mode === 'dev' || mode === 'development',
+        enabled: false,
         launchEditor: 'cursor'
       }),
       // Bundle Analyzer - 분석 모드에서만 활성화

--- a/apps/mobile/vite.config.ts
+++ b/apps/mobile/vite.config.ts
@@ -13,10 +13,9 @@ export default defineConfig(({ mode }) => {
     ...commonConfig,
     plugins: [
       vue(),
-      // Vue Inspector - 개발 모드에서만 활성화
       VueInspector({
         toggleComboKey: 'alt',
-        enabled: mode === 'dev' || mode === 'development',
+        enabled: false,
         launchEditor: 'cursor'
       }),
       // Bundle Analyzer - 분석 모드에서만 활성화

--- a/apps/sample-desktop/vite.config.ts
+++ b/apps/sample-desktop/vite.config.ts
@@ -14,12 +14,11 @@ export default defineConfig(({ mode }) => {
     ...commonConfig,
     plugins: [
       vue(),
-      // Vue Inspector - 개발 모드에서만 활성화  
-      // VueInspector({
-      //   toggleComboKey: 'alt',
-      //   enabled: mode === 'dev' || mode === 'development',
-      //   launchEditor: 'cursor'
-      // }),
+      VueInspector({
+        toggleComboKey: 'alt',
+        enabled: false,
+        launchEditor: 'cursor'
+      }),
       // Bundle Analyzer - 분석 모드에서만 활성화
       ...(isAnalyze ? [
         visualizer({


### PR DESCRIPTION
얼마 전에 적용했던 `vue-inspector` 초기 로딩 시에 비활성화되고, alt(option)키 입력 시 비활성화로 토글되도록 기본 설정 수정했습니다.